### PR TITLE
Added a new option to toggle Always on Top (floating window).

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -52,6 +52,14 @@ function createWindow(name, options, showOnStart = true) {
     show: showOnStart,
   });
 
+  win.onAlwaysOnTop = function(alwaysOnTop) {
+    if (alwaysOnTop === false) {
+      win.setAlwaysOnTop(false);
+    } else {
+      win.setAlwaysOnTop(true, 'floating', 1);
+    }
+  };
+
   win.on("close", (event) => {
     if (!win.isFullScreen()) {
       const bounds = win.getBounds();
@@ -140,7 +148,7 @@ app.whenReady().then(async () => {
 
   const mainWindow = createMainWindow();
   const displayWindow = createDisplayWindow();
-  displayWindow.setAlwaysOnTop(true, "floating", 1);
+  displayWindow.onAlwaysOnTop(settings.display.alwaysOnTop);
 
   if (settings.control.deviceId && settings.control.deviceId.includes("|adb")) {
     [controlIp, controlType] = settings.control.deviceId.split("|");
@@ -258,6 +266,13 @@ app.whenReady().then(async () => {
   ipcMain.on("save-show-settings-on-start", (event, showSettingsOnStart) => {
     settings.display.showSettingsOnStart = showSettingsOnStart;
     saveSettings(settings);
+  });
+
+  ipcMain.on("save-always-on-top", (event, alwaysOnTop) => {
+    settings.display.alwaysOnTop = alwaysOnTop;
+    saveSettings(settings);
+
+    displayWindow.onAlwaysOnTop(alwaysOnTop);
   });
 
   ipcMain.handle("select-adb-path", async () => {

--- a/public/main.js
+++ b/public/main.js
@@ -52,14 +52,6 @@ function createWindow(name, options, showOnStart = true) {
     show: showOnStart,
   });
 
-  win.onAlwaysOnTop = function(alwaysOnTop) {
-    if (alwaysOnTop === false) {
-      win.setAlwaysOnTop(false);
-    } else {
-      win.setAlwaysOnTop(true, 'floating', 1);
-    }
-  };
-
   win.on("close", (event) => {
     if (!win.isFullScreen()) {
       const bounds = win.getBounds();
@@ -113,6 +105,14 @@ function createDisplayWindow() {
   return win;
 }
 
+function setAlwaysOnTop(alwaysOnTop, window) {
+  if (alwaysOnTop === false) {
+    window.setAlwaysOnTop(false);
+  } else {
+    window.setAlwaysOnTop(true, 'floating', 1);
+  }
+}
+
 function registerShortcut(shortcut, window) {
   globalShortcut.unregisterAll();
   globalShortcut.register(shortcut, () => {
@@ -148,7 +148,7 @@ app.whenReady().then(async () => {
 
   const mainWindow = createMainWindow();
   const displayWindow = createDisplayWindow();
-  displayWindow.onAlwaysOnTop(settings.display.alwaysOnTop);
+  setAlwaysOnTop(settings.display.alwaysOnTop, displayWindow);
 
   if (settings.control.deviceId && settings.control.deviceId.includes("|adb")) {
     [controlIp, controlType] = settings.control.deviceId.split("|");
@@ -272,7 +272,7 @@ app.whenReady().then(async () => {
     settings.display.alwaysOnTop = alwaysOnTop;
     saveSettings(settings);
 
-    displayWindow.onAlwaysOnTop(alwaysOnTop);
+    setAlwaysOnTop(alwaysOnTop, displayWindow);
   });
 
   ipcMain.handle("select-adb-path", async () => {

--- a/src/components/DisplaySection.js
+++ b/src/components/DisplaySection.js
@@ -14,6 +14,7 @@ function DisplaySection() {
   const [shortcut, setShortcut] = useState("");
   const [launchAppAtLogin, setLaunchAppAtLogin] = useState(false);
   const [showSettingsOnStart, setShowSettingsOnStart] = useState(true);
+  const [alwaysOnTop, setAlwaysOnTop] = useState(true);
 
   useEffect(() => {
     // Load settings from main process
@@ -34,6 +35,9 @@ function DisplaySection() {
       }
       if (settings.display && settings.display.showSettingsOnStart !== undefined) {
         setShowSettingsOnStart(settings.display.showSettingsOnStart);
+      }
+      if (settings.display && settings.display.alwaysOnTop !== undefined) {
+        setAlwaysOnTop(settings.display.alwaysOnTop);
       }
     });
   }, []);
@@ -61,6 +65,11 @@ function DisplaySection() {
   const handleShowSettingsOnStartChange = (e) => {
     setShowSettingsOnStart(e.target.checked);
     electronAPI.send("save-show-settings-on-start", e.target.checked);
+  };
+
+  const handleAlwaysOnTopChange = (e) => {
+    setAlwaysOnTop(e.target.checked);
+    electronAPI.send("save-always-on-top", e.target.checked);
   };
 
   return (
@@ -101,6 +110,12 @@ function DisplaySection() {
                 label="Settings on App Start"
                 checked={showSettingsOnStart}
                 onChange={handleShowSettingsOnStartChange}
+              />
+              <Form.Check
+                type="checkbox"
+                label="Always on Top"
+                checked={alwaysOnTop}
+                onChange={handleAlwaysOnTopChange}
               />
             </Col>
           </Row>


### PR DESCRIPTION
First off, I just wanted to say that this tool is fantastic, and I’m excited to see where it goes!

This PR adds an option to toggle the 'Always on Top' feature. This feature gives users more control over their experience by allowing them to choose whether they want the window to stay on top, while maintaining the default behavior. This also makes the capture window shareable during meetings, as platforms like Google Meet do not include windows that are always on top.

I hope this PR comes across in the right spirit, just trying to contribute and not step on any toes. Let me know what you think!