### PR TITLE
Fix Crash when there is no `settings.json` file

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -120,7 +120,7 @@ function createMainWindow() {
 }
 
 function createDisplayWindow() {
-  if (settings.display.resolution.includes("px")) {
+  if (settings.display?.resolution?.includes("px")) {
     lastSize = settings.display.resolution
       .split("|")
       .map((dim) => parseInt(dim.replace("px", ""), 10) + 15);
@@ -195,7 +195,7 @@ app.whenReady().then(async () => {
 
   const mainWindow = createMainWindow();
   const displayWindow = createDisplayWindow();
-  setAlwaysOnTop(settings.display.alwaysOnTop, displayWindow);
+  setAlwaysOnTop(settings.display.alwaysOnTop ?? true, displayWindow);
   if (process.platform === "darwin") {
     createMenu(mainWindow, displayWindow, packageInfo);
   }

--- a/public/main.js
+++ b/public/main.js
@@ -201,7 +201,6 @@ app.whenReady().then(async () => {
   }
   if (settings.control.deviceId && settings.control.deviceId.includes("|adb")) {
     [controlIp, controlType] = settings.control.deviceId.split("|");
-    console.log("Control loaded from settings:", controlIp, controlType);
     if (!isADBConnected) {
       isADBConnected = connectADB(controlIp, settings.control.adbPath);
     }


### PR DESCRIPTION
When installing from scratch, there is no pre-existing settings file, and that was crashing the JavaScript.