### PR TITLE
Improved ECP performance and prevented render thread lock

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@ It is perfect for developers and QA engineers to execute and test applications u
 - Link capture devices with streaming devices
 - Allow user to record captured video to mp4/mkv file
 - Detect the list streaming devices in the network (SSDP)
-- Add missing ADB keyboard mapping
 
 ## Installation
 


### PR DESCRIPTION
Improved the ECP literal keys performance by sending `keypress` command instead of `keyup` and `keydown`.

The ECP code was using `XMLHttpRequest` that is synchronous and blocks the render thread when the ECP device is not reachable anymore, now we are using `Fetch` and an async queue to process keys, preventing any UI lock.

