### PR TITLE
[macOS] Hide the app (to lose focus) when both windows are hidden

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -220,17 +220,15 @@ app.whenReady().then(async () => {
     registerShortcut(settings.display.shortcut, displayWindow);
   }
 
-  // Add macOS focus management - hide app when both windows are hidden
+  // Hide app when both windows are hidden in macOS
   if (isMacOS) {
     mainWindow.on("hide", () => {
-      // Hide app if both windows are hidden
       if (!displayWindow.isVisible()) {
         app.hide();
       }
     });
 
     displayWindow.on("hide", () => {
-      // Hide app if both windows are hidden
       if (!mainWindow.isVisible()) {
         app.hide();
       }

--- a/public/main.js
+++ b/public/main.js
@@ -220,6 +220,23 @@ app.whenReady().then(async () => {
     registerShortcut(settings.display.shortcut, displayWindow);
   }
 
+  // Add macOS focus management - hide app when both windows are hidden
+  if (isMacOS) {
+    mainWindow.on("hide", () => {
+      // Hide app if both windows are hidden
+      if (!displayWindow.isVisible()) {
+        app.hide();
+      }
+    });
+
+    displayWindow.on("hide", () => {
+      // Hide app if both windows are hidden
+      if (!mainWindow.isVisible()) {
+        app.hide();
+      }
+    });
+  }
+
   ipcMain.on("shared-window-channel", (event, arg) => {
     displayWindow.webContents.send("shared-window-channel", arg);
     saveFlag = true;


### PR DESCRIPTION
Currently the app is keeping the focus in macOS even when both windows are hidden, this PR fixes this behavior.