### PR TITLE
Support `macOS` paste system menu

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -144,7 +144,6 @@ function createDisplayWindow() {
   win.on("move", () => {
     win.webContents.send("window-moved");
   });
-
   return win;
 }
 

--- a/public/main.js
+++ b/public/main.js
@@ -144,6 +144,16 @@ function createDisplayWindow() {
   win.on("move", () => {
     win.webContents.send("window-moved");
   });
+
+  // Handle paste operations for macOS system menu
+  win.webContents.on("before-input-event", (event, input) => {
+    if (input.meta && input.key === "v" && input.type === "keyDown") {
+      console.debug("[Main] Paste shortcut detected via before-input-event");
+      win.webContents.send("handle-paste");
+      event.preventDefault();
+    }
+  });
+
   return win;
 }
 

--- a/public/main.js
+++ b/public/main.js
@@ -145,15 +145,6 @@ function createDisplayWindow() {
     win.webContents.send("window-moved");
   });
 
-  // Handle paste operations for macOS system menu
-  win.webContents.on("before-input-event", (event, input) => {
-    if (input.meta && input.key === "v" && input.type === "keyDown") {
-      console.debug("[Main] Paste shortcut detected via before-input-event");
-      win.webContents.send("handle-paste");
-      event.preventDefault();
-    }
-  });
-
   return win;
 }
 

--- a/public/render.js
+++ b/public/render.js
@@ -319,7 +319,6 @@ window.addEventListener("DOMContentLoaded", function () {
   if (isMacOS) {
     // Listen for the standard 'paste' event on the document
     document.addEventListener("paste", (event) => {
-      console.debug("[Carabiner] Paste event detected via document listener");
       event.preventDefault();
       handlePaste();
     });
@@ -327,7 +326,6 @@ window.addEventListener("DOMContentLoaded", function () {
     // Also listen for beforeinput events which can capture paste operations
     document.addEventListener("beforeinput", (event) => {
       if (event.inputType === "insertFromPaste" || event.inputType === "insertCompositionText") {
-        console.debug("[Carabiner] Paste operation detected via beforeinput event");
         event.preventDefault();
         handlePaste();
       }

--- a/public/render.js
+++ b/public/render.js
@@ -314,6 +314,31 @@ window.addEventListener("DOMContentLoaded", function () {
     handlePaste();
   });
 
+  // Additional paste detection for macOS system menu paste
+  // Listen for clipboard events and paste operations
+  if (isMacOS) {
+    // Listen for the standard 'paste' event on the document
+    document.addEventListener("paste", (event) => {
+      console.debug("[Carabiner] Paste event detected via document listener");
+      event.preventDefault();
+      handlePaste();
+    });
+
+    // Also listen for beforeinput events which can capture paste operations
+    document.addEventListener("beforeinput", (event) => {
+      if (event.inputType === "insertFromPaste" || event.inputType === "insertCompositionText") {
+        console.debug("[Carabiner] Paste operation detected via beforeinput event");
+        event.preventDefault();
+        handlePaste();
+      }
+    });
+
+    // Set focus to document to ensure it can receive paste events
+    document.addEventListener("click", () => {
+      document.focus();
+    });
+  }
+
   // Configure the overlay image
   overlayImage.style.position = "absolute";
   updateOverlayPosition();


### PR DESCRIPTION
The system menu Paste command was not being handled in macOS