### PR TITLE
Disabled `noiseSuppression` and `echoCancellation` in audio capture

### DIFF
--- a/public/render.js
+++ b/public/render.js
@@ -142,7 +142,11 @@ async function updateAudioConstraints() {
 
         if (audioDevice) {
           currentConstraints.audio = {
-            deviceId: { exact: audioDevice.deviceId },
+            deviceId: {
+              exact: audioDevice.deviceId,
+            },
+            noiseSuppression: false,
+            echoCancellation: false,
           };
           console.debug(
             `[Carabiner] Found matching audio device: ${audioDevice.label} for video device: ${videoDevice.label}`


### PR DESCRIPTION
These settings are on by default and cause bad captured sound on capture cards, those are designed for microphones