### PR TITLE
Add Automation tab with script recording and playback features

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -6,6 +6,10 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Carabiner is an Electron desktop app for streaming device development and QA. It shows live video from a capture card (HDMI capture device) in a floating overlay window, while letting users control Roku devices via ECP (HTTP) or Android/Fire TV/Google TV devices via ADB. Primary users are developers testing streaming apps without a physical TV.
 
+## Workflow
+
+Always create a new git branch before starting work on any new feature or fix. Never work directly on `main`.
+
 ## Commands
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Perfect for developers and QA engineers who need to test streaming applications 
 - **Keyboard Control**: Use your computer keyboard to navigate and control devices
 - **Text Pasting**: Paste clipboard content directly to streaming devices
 - **Screenshot Capture**: Save or copy screenshots with one click
+- **Automation Scripts**: Record key sequences with precise timing and replay them on demand
 
 ### Additional Features
 

--- a/docs/building-from-source.md
+++ b/docs/building-from-source.md
@@ -8,6 +8,7 @@ Ensure you have the following installed on your system:
 
 - **Node.js**: v18.0 or higher
 - **Git**: For cloning the repository
+- **Electron**: v42 (installed automatically via `npm install`)
 - **Platform-specific tools**:
   - **macOS**: Xcode Command Line Tools
   - **Windows**: Visual Studio Build Tools or Visual Studio Community
@@ -44,9 +45,13 @@ The first command builds the React frontend, and the second starts the Electron 
 ### Core Commands
 
 - **`npm run build`**: Build the React application for production
-- **`npm run forge`**: Run the Electron app in development mode
-- **`npm run make`**: Create platform-specific installers
-- **`npm run publish`**: Publish the application as a draft release on GitHub
+- **`npm run forge`**: Run the Electron app (requires a prior `build`)
+- **`npm run debug`**: Build and run with `ELECTRON_IS_DEV=1` for development logging
+- **`npm run test`**: Run React component tests
+- **`npm run make`**: Create a platform-specific installer for the current OS (output: `out/make/`)
+- **`npm run make:mac`**: Create a universal macOS DMG (Intel + Apple Silicon)
+- **`npm run make:all`**: Create installers for macOS (universal), Windows (x64), and Linux (x64)
+- **`npm run publish`**: Build and publish a draft release to GitHub
 
 ## Creating Installers
 
@@ -60,28 +65,54 @@ npm run make
 
 The installer will be created in the `./out/make` directory.
 
+### macOS Universal Binary
+
+```console
+npm run make:mac
+```
+
+Produces a single DMG that runs natively on both Intel and Apple Silicon Macs.
+
+> **macOS notarization** requires the `APPLE_ID`, `APPLE_PASSWORD`, and `APPLE_TEAM_ID` environment variables to be set before running `make:mac` or `publish`.
+
+### All Platforms
+
+```console
+npm run make:all
+```
+
+Builds installers sequentially for macOS (universal DMG), Windows (x64), and Linux (x64).
+
 ## Project Structure
 
 ```console
 carabiner/
-├── public/             # Electron main process files
-│   ├── main.js         # Main Electron process
-│   ├── preload.js      # Bridge script between main and renderer processes
-│   ├── render.js       # Display window renderer
-│   ├── menu.js         # Application menus
-│   ├── settings.js     # Settings management
-│   ├── adb.js          # Android Debug Bridge integration
-│   └── updater.js      # Version check functionality
-├── src/                # React frontend source
-│   ├── App.js          # Main React application
-│   ├── index.js        # React entry point
-│   └── components/     # React components
-├── docs/               # Documentation
-├── images/             # Application icons and images
-├── build/              # Built React application
-├── out/                # Built Electron application
-├── forge.config.js     # Electron Forge configuration
-└── package.json        # Project configuration
+├── public/                   # Electron main process and display window files
+│   ├── main.js               # Main Electron process — window management and IPC routing
+│   ├── preload.js            # contextBridge — exposes electronAPI to both renderers
+│   ├── display.html          # Display window HTML (loaded by displayWindow)
+│   ├── render.js             # Display window renderer — video, keyboard, recording, scripts
+│   ├── menu.js               # macOS menu bar, system tray, and right-click context menu
+│   ├── settings.js           # Load/save settings.json from userData
+│   ├── adb.js                # Android Debug Bridge integration
+│   └── updater.js            # GitHub Releases version check
+├── src/                      # React frontend source (settings panel)
+│   ├── App.js                # Root component — tab layout
+│   ├── index.js              # React entry point
+│   └── components/           # One component per settings tab
+│       ├── GeneralSection.js # Capture device picker and device link
+│       ├── DisplaySection.js # Border, transparency, window options
+│       ├── ControlSection.js # Add/remove streaming devices, ADB path
+│       ├── AutomationSection.js # Script recording, playback, and step editing
+│       ├── OverlaySection.js # Reference image overlay with opacity control
+│       ├── FilesSection.js   # Default save paths for screenshots/recordings
+│       └── AboutSection.js   # Version info and links
+├── docs/                     # Documentation
+├── images/                   # Application icons and images
+├── build/                    # Built React application (generated)
+├── out/                      # Built Electron application and installers (generated)
+├── forge.config.js           # Electron Forge configuration
+└── package.json              # Project configuration
 ```
 
 ## Contributing to Development

--- a/docs/building-from-source.md
+++ b/docs/building-from-source.md
@@ -87,32 +87,32 @@ Builds installers sequentially for macOS (universal DMG), Windows (x64), and Lin
 
 ```console
 carabiner/
-├── public/                   # Electron main process and display window files
-│   ├── main.js               # Main Electron process — window management and IPC routing
-│   ├── preload.js            # contextBridge — exposes electronAPI to both renderers
-│   ├── display.html          # Display window HTML (loaded by displayWindow)
-│   ├── render.js             # Display window renderer — video, keyboard, recording, scripts
-│   ├── menu.js               # macOS menu bar, system tray, and right-click context menu
-│   ├── settings.js           # Load/save settings.json from userData
-│   ├── adb.js                # Android Debug Bridge integration
-│   └── updater.js            # GitHub Releases version check
-├── src/                      # React frontend source (settings panel)
-│   ├── App.js                # Root component — tab layout
-│   ├── index.js              # React entry point
-│   └── components/           # One component per settings tab
-│       ├── GeneralSection.js # Capture device picker and device link
-│       ├── DisplaySection.js # Border, transparency, window options
-│       ├── ControlSection.js # Add/remove streaming devices, ADB path
+├── public/                      # Electron main process and display window files
+│   ├── main.js                  # Main Electron process — window management and IPC routing
+│   ├── preload.js               # contextBridge — exposes electronAPI to both renderers
+│   ├── display.html             # Display window HTML (loaded by displayWindow)
+│   ├── render.js                # Display window renderer — video, keyboard, recording, scripts
+│   ├── menu.js                  # macOS menu bar, system tray, and right-click context menu
+│   ├── settings.js              # Load/save settings.json from userData
+│   ├── adb.js                   # Android Debug Bridge integration
+│   └── updater.js               # GitHub Releases version check
+├── src/                         # React frontend source (settings panel)
+│   ├── App.js                   # Root component — tab layout
+│   ├── index.js                 # React entry point
+│   └── components/              # One component per settings tab
+│       ├── GeneralSection.js    # Capture device picker and device link
+│       ├── DisplaySection.js    # Border, transparency, window options
+│       ├── ControlSection.js    # Add/remove streaming devices, ADB path
 │       ├── AutomationSection.js # Script recording, playback, and step editing
-│       ├── OverlaySection.js # Reference image overlay with opacity control
-│       ├── FilesSection.js   # Default save paths for screenshots/recordings
-│       └── AboutSection.js   # Version info and links
-├── docs/                     # Documentation
-├── images/                   # Application icons and images
-├── build/                    # Built React application (generated)
-├── out/                      # Built Electron application and installers (generated)
-├── forge.config.js           # Electron Forge configuration
-└── package.json              # Project configuration
+│       ├── OverlaySection.js    # Reference image overlay with opacity control
+│       ├── FilesSection.js      # Default save paths for screenshots/recordings
+│       └── AboutSection.js      # Version info and links
+├── docs/                        # Documentation
+├── images/                      # Application icons and images
+├── build/                       # Built React application (generated)
+├── out/                         # Built Electron application and installers (generated)
+├── forge.config.js              # Electron Forge configuration
+└── package.json                 # Project configuration
 ```
 
 ## Contributing to Development

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -25,6 +25,7 @@ After installing Carabiner, launch the application to access the settings window
 3. Click "Add Device" to register a new streaming device
 
 > **Roku users — enable ECP first:** Carabiner communicates with Roku devices via the External Control Protocol (ECP). Before adding a Roku device, make sure ECP is enabled:
+>
 > 1. Press the **Home** button on your Roku remote.
 > 2. Go to **Settings > System > Advanced system settings**.
 > 3. Select **Control by mobile apps**.
@@ -110,6 +111,7 @@ The **Automation** tab lets you record key sequences (with the exact timing betw
 
 - Click the **▶** button next to any script in the list, or
 - Use the **File → Run Script** submenu (also available in the tray and right-click context menu).
+- Click the **■** button to interrupt playback.
 
 **Editing a script:**
 

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -24,6 +24,12 @@ After installing Carabiner, launch the application to access the settings window
    - **Type**: Select Roku, Fire TV or Google TV
 3. Click "Add Device" to register a new streaming device
 
+> **Roku users — enable ECP first:** Carabiner communicates with Roku devices via the External Control Protocol (ECP). Before adding a Roku device, make sure ECP is enabled:
+> 1. Press the **Home** button on your Roku remote.
+> 2. Go to **Settings > System > Advanced system settings**.
+> 3. Select **Control by mobile apps**.
+> 4. Set to **Enabled** or **Permissive**.
+
 ### 3. Link Devices
 
 1. Return to the **General** tab
@@ -88,6 +94,34 @@ Record your streaming device sessions (in MP4/WebM) for documentation, tutorials
 - **Interactive Save Notifications**: Click the toast notification after saving to open the containing folder
 
 > **💡 Tip**: Recordings capture what you see in the display window, perfect for creating tutorials or documenting app behavior! After saving, click the toast notification to quickly navigate to your saved file.
+
+### Automation Scripts
+
+The **Automation** tab lets you record key sequences (with the exact timing between keypresses) and replay them on demand. This is useful for repetitive test flows — navigating to a menu, resetting app state, launching a specific screen — that you would otherwise repeat manually every session.
+
+**Recording a script:**
+
+1. Open the **Automation** tab in settings.
+2. Click **Start Recording** (or press `Cmd+Shift+A` on macOS / `Ctrl+Shift+A` on Windows/Linux).
+3. Switch focus to the display window and press the keys you want to record. Each keypress is captured along with the delay since the previous key.
+4. Press **Stop Recording** (or `Cmd+Shift+Z` / `Ctrl+Shift+Z`) when done. The script is saved automatically.
+
+**Playing back a script:**
+
+- Click the **▶** button next to any script in the list, or
+- Use the **File → Run Script** submenu (also available in the tray and right-click context menu).
+
+**Editing a script:**
+
+- **Rename**: Click the **✎** (pencil) button and type a new name.
+- **Edit steps**: Click the **≡** button to expand the step editor. From there you can:
+  - Change the delay before any step (in milliseconds, 0–5000).
+  - Reorder steps with **↑** / **↓**.
+  - Remove individual steps with **✕**.
+- Click **Save Changes** to apply edits or **Cancel** to revert.
+- Click **🗑** to delete a script entirely.
+
+> **Note:** Scripts are tied to the protocol of the device that was active when they were recorded (ECP for Roku, ADB for Android). Playing a script on a device with a different protocol will show a warning toast, but playback will still proceed.
 
 ### Overlay Images
 

--- a/public/main.js
+++ b/public/main.js
@@ -1039,6 +1039,10 @@ app.whenReady().then(async () => {
     }
   });
 
+  ipcMain.on("stop-script", () => {
+    displayWindow?.webContents.send("stop-script");
+  });
+
   ipcMain.on("script-playback-done", (event, scriptId) => {
     isScriptPlaying = false;
     updateScriptRecordingMenuItems(isScriptRecording, isScriptRecording);

--- a/public/main.js
+++ b/public/main.js
@@ -32,6 +32,8 @@ const {
   updateScreenshotMenuItems,
   updateRecordingMenuItems,
   updateShowDisplayMenuItem,
+  updateScriptRecordingMenuItems,
+  updateScriptsSubmenu,
   createTrayMenu,
   updateTrayRecordingMenuItems,
   toggleDockIcon,
@@ -58,6 +60,8 @@ let isADBConnected = false;
 let isQuitting = false;
 let captureDevices;
 let isCurrentlyRecording = false;
+let isScriptRecording = false;
+let isScriptPlaying = false;
 let saveFlag = false;
 
 const appLauncher = new AutoLaunch({
@@ -127,9 +131,9 @@ function createMainWindow() {
     "mainWindow",
     {
       height: isMacOS ? 620 : 645,
-      width: 630,
+      width: 700,
       minHeight: isMacOS ? 620 : 645,
-      minWidth: 630,
+      minWidth: 700,
       maximizable: false,
       resizable: false,
       autoHideMenuBar: true,
@@ -440,11 +444,19 @@ app.whenReady().then(async () => {
   displayWindow.on("hide", () => {
     displayWindow.webContents.send("window-hide");
     updateShowDisplayMenuItem(false);
+    if (isScriptRecording) {
+      isScriptRecording = false;
+      updateScriptRecordingMenuItems(false, false);
+    }
   });
 
   displayWindow.on("minimize", () => {
     displayWindow.webContents.send("window-minimize");
     updateShowDisplayMenuItem(false);
+    if (isScriptRecording) {
+      isScriptRecording = false;
+      updateScriptRecordingMenuItems(false, false);
+    }
   });
 
   displayWindow.on("restore", () => {
@@ -748,7 +760,9 @@ app.whenReady().then(async () => {
       packageInfo,
       isCurrentlyRecording,
       captureDevices,
-      settings
+      settings,
+      isScriptRecording,
+      isScriptPlaying
     );
     menu.popup({ window: displayWindow });
   });
@@ -969,6 +983,66 @@ app.whenReady().then(async () => {
     }
   });
 
+  // Script recording controls — forwarded to display window
+  ipcMain.on("start-script-recording", () => {
+    if (!isScriptRecording) {
+      isScriptRecording = true;
+      updateScriptRecordingMenuItems(true, true);
+      mainWindow?.webContents.send("script-recording-state-changed", true);
+      displayWindow?.webContents.send("start-script-recording");
+    }
+  });
+
+  ipcMain.on("stop-script-recording", () => {
+    if (isScriptRecording) {
+      displayWindow?.webContents.send("stop-script-recording");
+    }
+  });
+
+  ipcMain.on("script-recording-state-changed", (event, recording) => {
+    isScriptRecording = recording;
+    updateScriptRecordingMenuItems(recording, recording);
+    mainWindow?.webContents.send("script-recording-state-changed", recording);
+  });
+
+  ipcMain.on("save-script", (event, script) => {
+    if (!settings.scripts) settings.scripts = [];
+    script.name = `Script ${settings.scripts.length + 1}`;
+    settings.scripts.push(script);
+    saveSettings(settings);
+    isScriptRecording = false;
+    updateScriptRecordingMenuItems(false, false);
+    mainWindow?.webContents.send("script-recording-state-changed", false);
+    mainWindow?.webContents.send("shared-window-channel", {
+      type: "scripts-updated",
+      payload: settings.scripts,
+    });
+    updateScriptsSubmenu(settings.scripts, mainWindow, displayWindow, packageInfo, settings);
+    const tray = getTray();
+    if (tray) {
+      createTrayMenu(mainWindow, displayWindow, packageInfo, captureDevices, settings, isCurrentlyRecording);
+    }
+  });
+
+  ipcMain.on("run-script", (event, scriptId) => {
+    const script = settings.scripts?.find((s) => s.id === scriptId);
+    if (script) {
+      isScriptPlaying = true;
+      updateScriptRecordingMenuItems(isScriptRecording || isScriptPlaying, isScriptRecording);
+      displayWindow?.webContents.send("play-script", {
+        id: script.id,
+        steps: script.steps,
+        controlType: script.controlType,
+      });
+    }
+  });
+
+  ipcMain.on("script-playback-done", (event, scriptId) => {
+    isScriptPlaying = false;
+    updateScriptRecordingMenuItems(isScriptRecording, isScriptRecording);
+    mainWindow?.webContents.send("script-playback-done", scriptId);
+  });
+
   app.on("activate", () => {
     if (BrowserWindow.getAllWindows().length === 0) {
       createMainWindow();
@@ -978,6 +1052,9 @@ app.whenReady().then(async () => {
     isQuitting = true;
     if (isADBConnected) {
       disconnectADB();
+    }
+    if (isScriptRecording) {
+      displayWindow?.webContents.send("discard-script-recording");
     }
   });
 });
@@ -1014,6 +1091,52 @@ ipcMain.on("save-recording-path", (event, recordingPath) => {
 ipcMain.on("renderer-log", (event, level, ...args) => {
   const fn = typeof log[level] === "function" ? log[level] : log.debug;
   fn.call(log, "[Renderer]", ...args);
+});
+
+// Script management handlers
+ipcMain.handle("get-scripts", async () => {
+  return settings.scripts || [];
+});
+
+ipcMain.on("update-script-name", (event, { id, name }) => {
+  const script = settings.scripts?.find((s) => s.id === id);
+  if (script) {
+    script.name = name.trim() || script.name;
+    saveSettings(settings);
+    const mainWindow = BrowserWindow.getAllWindows().find((w) => w.webContents.getURL().includes("index.html"));
+    const displayWindow = BrowserWindow.getAllWindows().find((w) => w.webContents.getURL().includes("display.html"));
+    mainWindow?.webContents.send("shared-window-channel", { type: "scripts-updated", payload: settings.scripts });
+    updateScriptsSubmenu(settings.scripts, mainWindow, displayWindow, packageInfo, settings);
+    const tray = getTray();
+    if (tray) {
+      createTrayMenu(mainWindow, displayWindow, packageInfo, null, settings, false);
+    }
+  }
+});
+
+ipcMain.on("update-script-steps", (event, { id, steps }) => {
+  const script = settings.scripts?.find((s) => s.id === id);
+  if (script) {
+    script.steps = steps;
+    saveSettings(settings);
+    const mainWindow = BrowserWindow.getAllWindows().find((w) => w.webContents.getURL().includes("index.html"));
+    mainWindow?.webContents.send("shared-window-channel", { type: "scripts-updated", payload: settings.scripts });
+  }
+});
+
+ipcMain.on("delete-script", (event, scriptId) => {
+  if (settings.scripts) {
+    settings.scripts = settings.scripts.filter((s) => s.id !== scriptId);
+    saveSettings(settings);
+    const mainWindow = BrowserWindow.getAllWindows().find((w) => w.webContents.getURL().includes("index.html"));
+    const displayWindow = BrowserWindow.getAllWindows().find((w) => w.webContents.getURL().includes("display.html"));
+    mainWindow?.webContents.send("shared-window-channel", { type: "scripts-updated", payload: settings.scripts });
+    updateScriptsSubmenu(settings.scripts, mainWindow, displayWindow, packageInfo, settings);
+    const tray = getTray();
+    if (tray) {
+      createTrayMenu(mainWindow, displayWindow, packageInfo, null, settings, false);
+    }
+  }
 });
 
 // Handler for opening folder containing file

--- a/public/main.js
+++ b/public/main.js
@@ -986,6 +986,7 @@ app.whenReady().then(async () => {
   // Script recording controls — forwarded to display window
   ipcMain.on("start-script-recording", () => {
     if (!isScriptRecording) {
+      if (displayWindow && !displayWindow.isVisible()) displayWindow.show();
       isScriptRecording = true;
       updateScriptRecordingMenuItems(true, true);
       mainWindow?.webContents.send("script-recording-state-changed", true);
@@ -1027,6 +1028,7 @@ app.whenReady().then(async () => {
   ipcMain.on("run-script", (event, scriptId) => {
     const script = settings.scripts?.find((s) => s.id === scriptId);
     if (script) {
+      if (displayWindow && !displayWindow.isVisible()) displayWindow.show();
       isScriptPlaying = true;
       updateScriptRecordingMenuItems(isScriptRecording || isScriptPlaying, isScriptRecording);
       displayWindow?.webContents.send("play-script", {

--- a/public/menu.js
+++ b/public/menu.js
@@ -18,6 +18,10 @@ let stopRecordingMenuItem;
 let showDisplayMenuItem;
 let enableAudioMenuItem;
 
+// Script recording menu item references
+let startScriptRecordingMenuItem = null;
+let stopScriptRecordingMenuItem = null;
+
 // Tray-related variables
 let tray = null;
 let trayContextMenu = null;
@@ -25,10 +29,19 @@ let trayStartRecordingItem = null;
 let trayStopRecordingItem = null;
 let trayAlwaysOnTopItem = null;
 let trayEnableAudioItem = null;
+let trayStartScriptRecordingItem = null;
+let trayStopScriptRecordingItem = null;
 
 // Context menu variables
 let contextAlwaysOnTopItem = null;
 let contextEnableAudioItem = null;
+
+// Stored window refs for menu rebuild (scripts submenu)
+let _storedMainWindow = null;
+let _storedDisplayWindow = null;
+let _storedPackageInfo = null;
+let _storedSettings = null;
+let _storedCaptureDevices = null;
 
 const isMacOS = process.platform === "darwin";
 const isWindows = process.platform === "win32";
@@ -42,6 +55,8 @@ const ACCELERATORS = {
   copyScreenshot: "CmdOrCtrl+Shift+C",
   startRecording: "CmdOrCtrl+Shift+R",
   stopRecording: "CmdOrCtrl+Shift+S",
+  startScriptRecording: "CmdOrCtrl+Shift+A",
+  stopScriptRecording: "CmdOrCtrl+Shift+Z",
   closeWindow: "CmdOrCtrl+W",
   paste: "CmdOrCtrl+V",
 };
@@ -171,6 +186,45 @@ const MenuItems = {
       }
     },
   }),
+
+  startScriptRecording: (mainWindow, enabled = true) => ({
+    id: "start-script-recording",
+    label: "Start Script Recording",
+    accelerator: ACCELERATORS.startScriptRecording,
+    enabled,
+    click: () => {
+      const { ipcMain } = require("electron");
+      ipcMain.emit("start-script-recording");
+    },
+  }),
+
+  stopScriptRecording: (mainWindow, enabled = false) => ({
+    id: "stop-script-recording",
+    label: "Stop Script Recording",
+    accelerator: ACCELERATORS.stopScriptRecording,
+    enabled,
+    click: () => {
+      const { ipcMain } = require("electron");
+      ipcMain.emit("stop-script-recording");
+    },
+  }),
+
+  scriptsSubmenu: (scripts, displayWindow) => ({
+    label: "Run Script",
+    enabled: scripts && scripts.length > 0,
+    submenu:
+      scripts && scripts.length > 0
+        ? scripts.map((s) => ({
+            label: s.name,
+            click: () =>
+              displayWindow?.webContents.send("play-script", {
+                id: s.id,
+                steps: s.steps,
+                controlType: s.controlType,
+              }),
+          }))
+        : [{ label: "No scripts saved", enabled: false }],
+  }),
 };
 
 // Common help menu items
@@ -236,6 +290,13 @@ const AppMenuItems = {
 };
 
 function createMacOSMenu(mainWindow, displayWindow, packageInfo, settings) {
+  _storedMainWindow = mainWindow;
+  _storedDisplayWindow = displayWindow;
+  _storedPackageInfo = packageInfo;
+  _storedSettings = settings;
+
+  const scripts = settings?.scripts || [];
+
   const template = [
     // Add macOS-specific app menu
     ...[AppMenuItems.macOS(mainWindow)],
@@ -247,6 +308,11 @@ function createMacOSMenu(mainWindow, displayWindow, packageInfo, settings) {
         MenuItems.separator(),
         MenuItems.startRecording(displayWindow, false),
         MenuItems.stopRecording(displayWindow, false),
+        MenuItems.separator(),
+        MenuItems.startScriptRecording(mainWindow, true),
+        MenuItems.stopScriptRecording(mainWindow, false),
+        MenuItems.separator(),
+        MenuItems.scriptsSubmenu(scripts, displayWindow),
         MenuItems.separator(),
         AppMenuItems.closeWindow(settings),
       ],
@@ -302,6 +368,8 @@ function createMacOSMenu(mainWindow, displayWindow, packageInfo, settings) {
   stopRecordingMenuItem = menu.getMenuItemById("stop-recording");
   showDisplayMenuItem = menu.getMenuItemById("show-display");
   enableAudioMenuItem = menu.getMenuItemById("enable-audio");
+  startScriptRecordingMenuItem = menu.getMenuItemById("start-script-recording");
+  stopScriptRecordingMenuItem = menu.getMenuItemById("stop-script-recording");
 }
 
 function updateAlwaysOnTopMenuItem(value) {
@@ -349,6 +417,25 @@ function updateRecordingMenuItems(displayVisible, isRecording) {
 function updateShowDisplayMenuItem(isVisible) {
   if (showDisplayMenuItem) {
     showDisplayMenuItem.enabled = !isVisible;
+  }
+}
+
+function updateScriptRecordingMenuItems(disableStart, isRecording) {
+  if (startScriptRecordingMenuItem) startScriptRecordingMenuItem.enabled = !disableStart;
+  if (stopScriptRecordingMenuItem) stopScriptRecordingMenuItem.enabled = !!isRecording;
+  if (trayStartScriptRecordingItem) trayStartScriptRecordingItem.enabled = !disableStart;
+  if (trayStopScriptRecordingItem) trayStopScriptRecordingItem.enabled = !!isRecording;
+}
+
+function updateScriptsSubmenu(scripts, mainWindow, displayWindow, packageInfo, settings) {
+  if (_storedSettings) _storedSettings.scripts = scripts;
+  if (isMacOS && _storedMainWindow && _storedDisplayWindow) {
+    createMacOSMenu(
+      mainWindow || _storedMainWindow,
+      displayWindow || _storedDisplayWindow,
+      packageInfo || _storedPackageInfo,
+      settings || _storedSettings
+    );
   }
 }
 
@@ -410,6 +497,17 @@ function createTrayMenu(
     { ...MenuItems.stopRecording(displayWindow, isCurrentlyRecording), id: "tray-stop-recording" },
     MenuItems.separator(),
     {
+      ...MenuItems.startScriptRecording(mainWindow, true),
+      id: "tray-start-script-recording",
+    },
+    {
+      ...MenuItems.stopScriptRecording(mainWindow, false),
+      id: "tray-stop-script-recording",
+    },
+    MenuItems.separator(),
+    { ...MenuItems.scriptsSubmenu(settings?.scripts || [], displayWindow), id: "tray-scripts-submenu" },
+    MenuItems.separator(),
+    {
       ...MenuItems.alwaysOnTop(displayWindow, mainWindow),
       id: "tray-always-on-top",
       checked: settings?.display?.alwaysOnTop ?? displayWindow.isAlwaysOnTop(),
@@ -449,6 +547,8 @@ function createTrayMenu(
   trayStopRecordingItem = trayContextMenu.getMenuItemById("tray-stop-recording");
   trayAlwaysOnTopItem = trayContextMenu.getMenuItemById("tray-always-on-top");
   trayEnableAudioItem = trayContextMenu.getMenuItemById("tray-enable-audio");
+  trayStartScriptRecordingItem = trayContextMenu.getMenuItemById("tray-start-script-recording");
+  trayStopScriptRecordingItem = trayContextMenu.getMenuItemById("tray-stop-script-recording");
   updateTrayRecordingMenuItems(isCurrentlyRecording);
 
   // Set the context menu for the tray
@@ -540,7 +640,9 @@ function createContextMenu(
   packageInfo,
   isCurrentlyRecording,
   captureDevices = null,
-  settings = null
+  settings = null,
+  isScriptRecording = false,
+  isScriptPlaying = false
 ) {
   const menuItems = [
     MenuItems.copyScreenshot(displayWindow),
@@ -551,6 +653,11 @@ function createContextMenu(
       id: "start-recording-ctx",
     },
     { ...MenuItems.stopRecording(displayWindow, isCurrentlyRecording), id: "stop-recording-ctx" },
+    MenuItems.separator(),
+    { ...MenuItems.startScriptRecording(mainWindow, !(isScriptRecording || isScriptPlaying)), id: "ctx-start-script-recording" },
+    { ...MenuItems.stopScriptRecording(mainWindow, isScriptRecording), id: "ctx-stop-script-recording" },
+    MenuItems.separator(),
+    MenuItems.scriptsSubmenu(settings?.scripts || [], displayWindow),
     MenuItems.separator(),
     MenuItems.pasteText(displayWindow),
     MenuItems.separator(),
@@ -709,6 +816,8 @@ module.exports = {
   updateScreenshotMenuItems,
   updateRecordingMenuItems,
   updateShowDisplayMenuItem,
+  updateScriptRecordingMenuItems,
+  updateScriptsSubmenu,
   createTrayMenu,
   appendCaptureDevicesMenu,
   updateTrayRecordingMenuItems,

--- a/public/menu.js
+++ b/public/menu.js
@@ -91,7 +91,7 @@ const MenuItems = {
 
   startRecording: (displayWindow, enabled = false) => ({
     id: "start-recording",
-    label: "Start Recording",
+    label: "Start Video Recording",
     accelerator: ACCELERATORS.startRecording,
     enabled,
     click: () => {
@@ -104,7 +104,7 @@ const MenuItems = {
 
   stopRecording: (displayWindow, enabled = false) => ({
     id: "stop-recording",
-    label: "Stop Recording",
+    label: "Stop Video Recording",
     accelerator: ACCELERATORS.stopRecording,
     enabled,
     click: () => displayWindow?.webContents.send("stop-recording"),

--- a/public/render.js
+++ b/public/render.js
@@ -44,6 +44,14 @@ let isRecording = false;
 // Device monitoring variables
 let currentDeviceList = [];
 
+// Script recording/playback variables
+let isScriptRecording = false;
+let currentScriptSteps = [];
+let currentScriptControlType = "";
+let currentScriptId = null;
+let lastKeyTimestamp = null;
+let isPlayingScript = false;
+
 // Load settings from main process
 window.electronAPI.invoke("load-settings").then(async (settings) => {
   if (settings.control && settings.control.deviceId) {
@@ -358,12 +366,26 @@ window.addEventListener("DOMContentLoaded", function () {
     if (videoState !== "stopped") {
       stopVideoStream();
     }
+    if (isScriptRecording) {
+      isScriptRecording = false;
+      currentScriptSteps = [];
+      currentScriptId = null;
+      window.electronAPI.send("script-recording-state-changed", false);
+      showToast("Script recording cancelled.", 3000, true);
+    }
   });
 
   window.electronAPI.onMessageReceived("window-minimize", () => {
     // Window is minimized - stop video stream to save resources
     if (videoState !== "stopped") {
       stopVideoStream();
+    }
+    if (isScriptRecording) {
+      isScriptRecording = false;
+      currentScriptSteps = [];
+      currentScriptId = null;
+      window.electronAPI.send("script-recording-state-changed", false);
+      showToast("Script recording cancelled.", 3000, true);
     }
   });
 
@@ -418,6 +440,55 @@ window.addEventListener("DOMContentLoaded", function () {
     if (videoState === "stopped") {
       renderDisplay(currentConstraints);
     }
+  });
+
+  // Script recording IPC listeners
+  window.electronAPI.onMessageReceived("start-script-recording", () => {
+    if (isScriptRecording) return;
+    isScriptRecording = true;
+    currentScriptSteps = [];
+    currentScriptControlType = controlType;
+    currentScriptId = Date.now().toString(36) + Math.random().toString(36).slice(2);
+    lastKeyTimestamp = Date.now();
+    window.electronAPI.send("script-recording-state-changed", true);
+    showToast("Script recording started...");
+  });
+
+  window.electronAPI.onMessageReceived("stop-script-recording", () => {
+    if (!isScriptRecording) return;
+    isScriptRecording = false;
+    if (currentScriptSteps.length === 0) {
+      showToast("Script has no steps. Recording discarded.", 3000, true);
+      currentScriptId = null;
+      window.electronAPI.send("script-recording-state-changed", false);
+      return;
+    }
+    window.electronAPI.send("save-script", {
+      id: currentScriptId,
+      name: "",
+      controlType: currentScriptControlType,
+      steps: currentScriptSteps,
+    });
+    currentScriptSteps = [];
+    currentScriptId = null;
+    showToast("Script saved!");
+  });
+
+  window.electronAPI.onMessageReceived("play-script", (_, payload) => {
+    if (isScriptRecording) {
+      showToast("Cannot play script while recording.", 3000, true);
+      return;
+    }
+    playScript(payload.steps, payload.controlType).then(() => {
+      window.electronAPI.send("script-playback-done", payload.id);
+    });
+  });
+
+  window.electronAPI.onMessageReceived("discard-script-recording", () => {
+    isScriptRecording = false;
+    currentScriptSteps = [];
+    currentScriptId = null;
+    window.electronAPI.send("script-recording-state-changed", false);
   });
 
   const newWidth = window.innerWidth - widthOff;
@@ -512,6 +583,22 @@ window.addEventListener("DOMContentLoaded", function () {
       window.electronAPI.send("open-display-devtools");
       handled = true;
     }
+    // Start Script Recording: Ctrl+Shift+A / Cmd+Shift+A
+    const isStartScriptRecording =
+      (isMacOS && event.metaKey && event.shiftKey && key === "a") ||
+      (!isMacOS && event.ctrlKey && event.shiftKey && key === "a");
+    if (isStartScriptRecording) {
+      window.electronAPI.send("start-script-recording");
+      handled = true;
+    }
+    // Stop Script Recording: Ctrl+Shift+Z / Cmd+Shift+Z
+    const isStopScriptRecording =
+      (isMacOS && event.metaKey && event.shiftKey && key === "z") ||
+      (!isMacOS && event.ctrlKey && event.shiftKey && key === "z");
+    if (isStopScriptRecording) {
+      window.electronAPI.send("stop-script-recording");
+      handled = true;
+    }
 
     return handled;
   }
@@ -530,16 +617,20 @@ window.addEventListener("DOMContentLoaded", function () {
     if (controlType === "ecp") {
       const key = ecpKeysMap.get(keyCode);
       if (key && key.toLowerCase() !== "ignore") {
+        recordScriptStep(key, mod);
         sendKey(key, mod);
       } else if (
         !["Alt", "Control", "Meta", "Shift", "Tab", "Dead"].includes(event.key) &&
         mod === 0
       ) {
-        sendKey(`lit_${encodeURIComponent(event.key)}`, -1);
+        const litKey = `lit_${encodeURIComponent(event.key)}`;
+        recordScriptStep(litKey, -1);
+        sendKey(litKey, -1);
       }
     } else if (controlType === "adb") {
       const key = adbKeysMap.get(keyCode);
       if (key) {
+        recordScriptStep(key, mod);
         sendKey(key, mod);
       }
     }
@@ -1093,6 +1184,43 @@ async function typeText(text) {
       }
     }
   }
+}
+
+function recordScriptStep(key, mod) {
+  if (!isScriptRecording) return;
+  const delay = currentScriptSteps.length === 0 ? 0 : Date.now() - lastKeyTimestamp;
+  currentScriptSteps.push({ key, mod, delay });
+  lastKeyTimestamp = Date.now();
+}
+
+async function playScript(steps, scriptControlType) {
+  if (!steps || steps.length === 0) {
+    showToast("Script has no steps.", 2000, true);
+    return;
+  }
+  if (!isValidIP(controlIp)) {
+    showToast("No device connected for script playback!", 3000, true);
+    return;
+  }
+  if (isPlayingScript) {
+    showToast("A script is already playing.", 2000, true);
+    return;
+  }
+  if (scriptControlType && scriptControlType !== controlType) {
+    showToast(
+      `Warning: Script recorded for ${scriptControlType.toUpperCase()}, current device is ${controlType.toUpperCase()}.`,
+      4000,
+      true
+    );
+  }
+  isPlayingScript = true;
+  for (let i = 0; i < steps.length; i++) {
+    if (i > 0 && steps[i].delay > 0) {
+      await new Promise((resolve) => setTimeout(resolve, Math.min(steps[i].delay, 5000)));
+    }
+    sendKey(steps[i].key, steps[i].mod);
+  }
+  isPlayingScript = false;
 }
 
 function sendKey(key, mod) {

--- a/public/render.js
+++ b/public/render.js
@@ -51,6 +51,7 @@ let currentScriptControlType = "";
 let currentScriptId = null;
 let lastKeyTimestamp = null;
 let isPlayingScript = false;
+let scriptPlaybackCancelled = false;
 
 // Load settings from main process
 window.electronAPI.invoke("load-settings").then(async (settings) => {
@@ -489,6 +490,10 @@ window.addEventListener("DOMContentLoaded", function () {
     currentScriptSteps = [];
     currentScriptId = null;
     window.electronAPI.send("script-recording-state-changed", false);
+  });
+
+  window.electronAPI.onMessageReceived("stop-script", () => {
+    scriptPlaybackCancelled = true;
   });
 
   const newWidth = window.innerWidth - widthOff;
@@ -1214,13 +1219,17 @@ async function playScript(steps, scriptControlType) {
     );
   }
   isPlayingScript = true;
+  scriptPlaybackCancelled = false;
   for (let i = 0; i < steps.length; i++) {
+    if (scriptPlaybackCancelled) break;
     if (i > 0 && steps[i].delay > 0) {
       await new Promise((resolve) => setTimeout(resolve, Math.min(steps[i].delay, 5000)));
     }
+    if (scriptPlaybackCancelled) break;
     sendKey(steps[i].key, steps[i].mod);
   }
   isPlayingScript = false;
+  scriptPlaybackCancelled = false;
 }
 
 function sendKey(key, mod) {

--- a/public/settings.js
+++ b/public/settings.js
@@ -31,6 +31,7 @@ function loadSettings() {
       screenshotPath: "", // Empty string means use default (Pictures)
       recordingPath: "", // Empty string means use default (Movies on macOS, Videos elsewhere)
     },
+    scripts: [],
   };
   try {
     return Object.assign(defaultSettings, JSON.parse(fs.readFileSync(settingsFilePath)));

--- a/src/App.css
+++ b/src/App.css
@@ -80,12 +80,23 @@
 }
 
 .nav-tabs .nav-link {
-  padding: 0.5rem 1rem;
+  padding: 0.4rem 0.75rem;
 }
 
 /* Prevent body overflow */
 body {
   overflow: hidden;
+}
+
+/* Automation section script header */
+.script-header-row {
+  background-color: #f8f9fa;
+  color: #212529;
+}
+
+[data-bs-theme="dark"] .script-header-row {
+  background-color: #3d4349 !important;
+  color: #fff !important;
 }
 
 /* Dark Mode Styles */

--- a/src/App.js
+++ b/src/App.js
@@ -20,6 +20,7 @@ import ControlSection from "./components/ControlSection";
 import OverlaySection from "./components/OverlaySection";
 import FilesSection from "./components/FilesSection";
 import AboutSection from "./components/AboutSection";
+import AutomationSection from "./components/AutomationSection";
 
 const { electronAPI } = window;
 
@@ -92,6 +93,11 @@ function App() {
                 onUpdateStreamingDevices={handleUpdateStreamingDevices}
                 onDeletedDevice={handleDeletedDevice}
               />
+            </div>
+          </Tab>
+          <Tab eventKey="automation" title="Automation">
+            <div className="tab-content-container">
+              <AutomationSection />
             </div>
           </Tab>
           <Tab eventKey="overlay" title="Overlay">

--- a/src/components/AutomationSection.js
+++ b/src/components/AutomationSection.js
@@ -126,6 +126,11 @@ function AutomationSection() {
     electronAPI.send("run-script", script.id);
   };
 
+  const handleStop = () => {
+    setPlayingId(null);
+    electronAPI.send("stop-script");
+  };
+
   const handleRename = (script) => {
     setEditingNameId(script.id);
     setEditingName(script.name);
@@ -283,16 +288,28 @@ function AutomationSection() {
 
                 {/* Action buttons */}
                 <div className="d-flex gap-1">
-                  <Button
-                    size="sm"
-                    variant="outline-primary"
-                    disabled={isRecording || playingId === script.id}
-                    onClick={() => handlePlay(script)}
-                    title="Play script"
-                    style={{ fontSize: "0.75rem", padding: "2px 6px" }}
-                  >
-                    ▶
-                  </Button>
+                  {playingId === script.id ? (
+                    <Button
+                      size="sm"
+                      variant="warning"
+                      onClick={handleStop}
+                      title="Stop script"
+                      style={{ fontSize: "0.75rem", padding: "2px 6px" }}
+                    >
+                      ⏹
+                    </Button>
+                  ) : (
+                    <Button
+                      size="sm"
+                      variant="outline-primary"
+                      disabled={isRecording || isPlaying}
+                      onClick={() => handlePlay(script)}
+                      title="Play script"
+                      style={{ fontSize: "0.75rem", padding: "2px 6px" }}
+                    >
+                      ▶
+                    </Button>
+                  )}
                   <Button
                     size="sm"
                     variant="outline-primary"

--- a/src/components/AutomationSection.js
+++ b/src/components/AutomationSection.js
@@ -227,7 +227,7 @@ function AutomationSection() {
           onClick={handleStartRecording}
           title="Start Recording (Cmd+Shift+A on Mac / Ctrl+Shift+A on Win/Linux)"
         >
-          ⏺ Start Recording
+          ● Start Recording
         </Button>
         <Button
           size="sm"
@@ -236,7 +236,7 @@ function AutomationSection() {
           onClick={handleStopRecording}
           title="Stop Recording (Cmd+Shift+Z on Mac / Ctrl+Shift+Z on Win/Linux)"
         >
-          ⏹ Stop Recording
+          ■ Stop Recording
         </Button>
       </div>
 

--- a/src/components/AutomationSection.js
+++ b/src/components/AutomationSection.js
@@ -1,0 +1,428 @@
+/*---------------------------------------------------------------------------------------------
+ *  Carabiner - Simple Screen Capture and Remote Control App for Streaming Devices
+ *
+ *  Repository: https://github.com/lvcabral/carabiner
+ *
+ *  Copyright (c) 2024-2025 Marcelo Lv Cabral. All Rights Reserved.
+ *
+ *  Licensed under the MIT License. See LICENSE in the repository root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import React, { useState, useEffect, useRef } from "react";
+import { Button, Form, Badge, Alert } from "react-bootstrap";
+
+const { electronAPI } = window;
+
+// Friendly names for known key codes
+const KEY_LABELS = {
+  // ECP (Roku) keys
+  up: "Arrow Up",
+  down: "Arrow Down",
+  left: "Arrow Left",
+  right: "Arrow Right",
+  select: "Select",
+  back: "Back",
+  home: "Home",
+  play: "Play/Pause",
+  fwd: "Fast Forward",
+  rev: "Rewind",
+  info: "Info",
+  instantreplay: "Instant Replay",
+  volumemute: "Mute",
+  volumeup: "Volume Up",
+  volumedown: "Volume Down",
+  a: "A Button",
+  b: "B Button",
+  backspace: "Backspace",
+  // ADB (Android) keycodes
+  19: "Arrow Up",
+  20: "Arrow Down",
+  21: "Arrow Left",
+  22: "Arrow Right",
+  66: "Select/Enter",
+  4: "Back",
+  3: "Home",
+  85: "Play/Pause",
+  89: "Rewind",
+  90: "Fast Forward",
+  1: "Info",
+  67: "Backspace",
+  62: "Space",
+  164: "Mute",
+  29: "A Button",
+  54: "B Button",
+};
+
+function getKeyLabel(key) {
+  if (!key) return "Unknown";
+  // ECP literal character: lit_A, lit_%20, etc.
+  if (key.startsWith("lit_")) {
+    try {
+      return `Literal: ${decodeURIComponent(key.slice(4))}`;
+    } catch {
+      return `Literal: ${key.slice(4)}`;
+    }
+  }
+  return KEY_LABELS[key] || key;
+}
+
+function getModLabel(mod) {
+  if (mod === 0) return "Down";
+  if (mod === 100) return "Up";
+  return "Press";
+}
+
+function AutomationSection() {
+  const [scripts, setScripts] = useState([]);
+  const [isRecording, setIsRecording] = useState(false);
+  const [expandedId, setExpandedId] = useState(null);
+  const [editingNameId, setEditingNameId] = useState(null);
+  const [editingName, setEditingName] = useState("");
+  const [editedSteps, setEditedSteps] = useState([]);
+  const [playingId, setPlayingId] = useState(null);
+  const isPlaying = playingId !== null;
+  const nameInputRef = useRef(null);
+
+  useEffect(() => {
+    electronAPI.invoke("get-scripts").then((data) => {
+      setScripts(data || []);
+    });
+
+    const handleSharedChannel = (_, message) => {
+      if (message.type === "scripts-updated") {
+        setScripts(message.payload || []);
+      }
+    };
+    electronAPI.onMessageReceived("shared-window-channel", handleSharedChannel);
+
+    const handleRecordingState = (_, recording) => {
+      setIsRecording(recording);
+    };
+    electronAPI.onMessageReceived("script-recording-state-changed", handleRecordingState);
+
+    const handlePlaybackDone = (_, scriptId) => {
+      setPlayingId((prev) => (prev === scriptId ? null : prev));
+    };
+    electronAPI.onMessageReceived("script-playback-done", handlePlaybackDone);
+  }, []);
+
+  useEffect(() => {
+    if (editingNameId && nameInputRef.current) {
+      nameInputRef.current.focus();
+      nameInputRef.current.select();
+    }
+  }, [editingNameId]);
+
+  const handleStartRecording = () => {
+    electronAPI.send("start-script-recording");
+  };
+
+  const handleStopRecording = () => {
+    electronAPI.send("stop-script-recording");
+  };
+
+  const handlePlay = (script) => {
+    if (isRecording || playingId) return;
+    setPlayingId(script.id);
+    electronAPI.send("run-script", script.id);
+  };
+
+  const handleRename = (script) => {
+    setEditingNameId(script.id);
+    setEditingName(script.name);
+  };
+
+  const handleSaveRename = () => {
+    if (!editingName.trim()) return;
+    electronAPI.send("update-script-name", { id: editingNameId, name: editingName.trim() });
+    setEditingNameId(null);
+    setEditingName("");
+  };
+
+  const handleCancelRename = () => {
+    setEditingNameId(null);
+    setEditingName("");
+  };
+
+  const handleDelete = (scriptId) => {
+    if (expandedId === scriptId) setExpandedId(null);
+    electronAPI.send("delete-script", scriptId);
+  };
+
+  const handleEditSteps = (script) => {
+    if (expandedId === script.id) {
+      setExpandedId(null);
+      setEditedSteps([]);
+    } else {
+      setExpandedId(script.id);
+      setEditedSteps(script.steps.map((s) => ({ ...s })));
+    }
+  };
+
+  const handleSaveSteps = () => {
+    electronAPI.send("update-script-steps", { id: expandedId, steps: editedSteps });
+    setExpandedId(null);
+    setEditedSteps([]);
+  };
+
+  const handleCancelSteps = () => {
+    setExpandedId(null);
+    setEditedSteps([]);
+  };
+
+  const handleStepDelayChange = (index, value) => {
+    const updated = [...editedSteps];
+    updated[index] = { ...updated[index], delay: Math.max(0, Math.min(5000, parseInt(value) || 0)) };
+    setEditedSteps(updated);
+  };
+
+  const handleStepDelete = (index) => {
+    setEditedSteps(editedSteps.filter((_, i) => i !== index));
+  };
+
+  const handleStepMoveUp = (index) => {
+    if (index === 0) return;
+    const updated = [...editedSteps];
+    [updated[index - 1], updated[index]] = [updated[index], updated[index - 1]];
+    setEditedSteps(updated);
+  };
+
+  const handleStepMoveDown = (index) => {
+    if (index === editedSteps.length - 1) return;
+    const updated = [...editedSteps];
+    [updated[index], updated[index + 1]] = [updated[index + 1], updated[index]];
+    setEditedSteps(updated);
+  };
+
+  return (
+    <div className="p-2">
+      {/* Recording status banner */}
+      {isRecording && (
+        <Alert variant="danger" className="d-flex align-items-center py-2 mb-2" style={{ fontSize: "0.8rem" }}>
+          <span
+            style={{
+              display: "inline-block",
+              width: 10,
+              height: 10,
+              borderRadius: "50%",
+              backgroundColor: "#ff4444",
+              marginRight: 8,
+              animation: "pulse 1s infinite",
+            }}
+          />
+          <strong>Recording…</strong>&nbsp;Press Cmd+Shift+Z (Mac) / Ctrl+Shift+Z (Win/Linux) to stop.
+        </Alert>
+      )}
+
+      {/* Controls */}
+      <div className="d-flex gap-2 mb-3">
+        <Button
+          size="sm"
+          variant="danger"
+          disabled={isRecording || isPlaying}
+          onClick={handleStartRecording}
+        >
+          ⏺ Start Recording
+        </Button>
+        <Button
+          size="sm"
+          variant="secondary"
+          disabled={!isRecording}
+          onClick={handleStopRecording}
+        >
+          ⏹ Stop Recording
+        </Button>
+      </div>
+
+      <div style={{ fontSize: "0.75rem", color: "#6c757d", marginBottom: "0.5rem" }}>
+        Shortcuts: <strong>Cmd+Shift+A</strong> (Mac) / <strong>Ctrl+Shift+A</strong> (Win/Linux) to start, <strong>+Z</strong> to stop.
+      </div>
+
+      {/* Script list */}
+      {scripts.length === 0 ? (
+        <p className="text-muted" style={{ fontSize: "0.85rem" }}>
+          No scripts recorded yet. Press <strong>Start Recording</strong>, perform actions on your device, then press <strong>Stop Recording</strong>.
+        </p>
+      ) : (
+        <div>
+          {scripts.map((script) => (
+            <div key={script.id} className="mb-2 border rounded" style={{ overflow: "hidden" }}>
+              {/* Script header row */}
+              <div className="d-flex align-items-center p-2 gap-2 script-header-row">
+                {/* Name or rename input */}
+                {editingNameId === script.id ? (
+                  <div className="d-flex align-items-center gap-1 flex-grow-1">
+                    <Form.Control
+                      ref={nameInputRef}
+                      size="sm"
+                      value={editingName}
+                      onChange={(e) => setEditingName(e.target.value)}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter") handleSaveRename();
+                        if (e.key === "Escape") handleCancelRename();
+                      }}
+                      style={{ maxWidth: 200, fontSize: "0.8rem" }}
+                    />
+                    <Button size="sm" variant="primary" style={{ fontSize: "0.75rem", padding: "2px 6px" }} onClick={handleSaveRename}>
+                      Save
+                    </Button>
+                    <Button size="sm" variant="outline-secondary" style={{ fontSize: "0.75rem", padding: "2px 6px" }} onClick={handleCancelRename}>
+                      Cancel
+                    </Button>
+                  </div>
+                ) : (
+                  <span className="flex-grow-1 fw-semibold" style={{ fontSize: "0.85rem" }}>
+                    {script.name}
+                  </span>
+                )}
+
+                {/* Badges */}
+                <Badge bg="secondary" style={{ fontSize: "0.7rem" }}>
+                  {script.steps?.length ?? 0} steps
+                </Badge>
+                <Badge bg={script.controlType === "ecp" ? "info" : "warning"} text="dark" style={{ fontSize: "0.7rem" }}>
+                  {script.controlType?.toUpperCase() || "?"}
+                </Badge>
+
+                {/* Action buttons */}
+                <div className="d-flex gap-1">
+                  <Button
+                    size="sm"
+                    variant="outline-primary"
+                    disabled={isRecording || playingId === script.id}
+                    onClick={() => handlePlay(script)}
+                    title="Play script"
+                    style={{ fontSize: "0.75rem", padding: "2px 6px" }}
+                  >
+                    ▶
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="outline-primary"
+                    onClick={() => handleRename(script)}
+                    title="Rename script"
+                    style={{ fontSize: "0.75rem", padding: "2px 6px" }}
+                  >
+                    ✎
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant={expandedId === script.id ? "primary" : "outline-primary"}
+                    onClick={() => handleEditSteps(script)}
+                    title="Edit steps"
+                    style={{ fontSize: "0.75rem", padding: "2px 6px" }}
+                  >
+                    ≡
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="outline-danger"
+                    onClick={() => handleDelete(script.id)}
+                    title="Delete script"
+                    style={{ fontSize: "0.75rem", padding: "2px 6px" }}
+                  >
+                    🗑
+                  </Button>
+                </div>
+              </div>
+
+              {/* Step editor (expanded) */}
+              {expandedId === script.id && (
+                <div className="p-2" style={{ borderTop: "1px solid #dee2e6" }}>
+                  {editedSteps.length === 0 ? (
+                    <p className="text-muted mb-2" style={{ fontSize: "0.8rem" }}>No steps.</p>
+                  ) : (
+                    <table style={{ width: "100%", fontSize: "0.78rem", borderCollapse: "collapse" }}>
+                      <thead>
+                        <tr style={{ borderBottom: "1px solid #dee2e6" }}>
+                          <th style={{ padding: "3px 4px", width: 28 }}>#</th>
+                          <th style={{ padding: "3px 4px" }}>Key</th>
+                          <th style={{ padding: "3px 4px", width: 55 }}>Type</th>
+                          <th style={{ padding: "3px 4px", width: 90 }}>Delay (ms)</th>
+                          <th style={{ padding: "3px 4px", width: 80 }}>Actions</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {editedSteps.map((step, idx) => (
+                          <tr key={idx} style={{ borderBottom: "1px solid #f0f0f0" }}>
+                            <td style={{ padding: "3px 4px", color: "#6c757d" }}>{idx + 1}</td>
+                            <td style={{ padding: "3px 4px" }}>{getKeyLabel(step.key)}</td>
+                            <td style={{ padding: "3px 4px" }}>
+                              <Badge bg="light" text="dark" style={{ fontSize: "0.7rem" }}>
+                                {getModLabel(step.mod)}
+                              </Badge>
+                            </td>
+                            <td style={{ padding: "3px 4px" }}>
+                              <Form.Control
+                                type="number"
+                                size="sm"
+                                min={0}
+                                max={5000}
+                                value={step.delay}
+                                onChange={(e) => handleStepDelayChange(idx, e.target.value)}
+                                style={{ fontSize: "0.75rem", padding: "1px 4px", height: "auto" }}
+                              />
+                            </td>
+                            <td style={{ padding: "3px 4px" }}>
+                              <div className="d-flex gap-1">
+                                <Button
+                                  size="sm"
+                                  variant="outline-secondary"
+                                  disabled={idx === 0}
+                                  onClick={() => handleStepMoveUp(idx)}
+                                  style={{ fontSize: "0.65rem", padding: "1px 4px" }}
+                                  title="Move up"
+                                >
+                                  ↑
+                                </Button>
+                                <Button
+                                  size="sm"
+                                  variant="outline-secondary"
+                                  disabled={idx === editedSteps.length - 1}
+                                  onClick={() => handleStepMoveDown(idx)}
+                                  style={{ fontSize: "0.65rem", padding: "1px 4px" }}
+                                  title="Move down"
+                                >
+                                  ↓
+                                </Button>
+                                <Button
+                                  size="sm"
+                                  variant="outline-danger"
+                                  onClick={() => handleStepDelete(idx)}
+                                  style={{ fontSize: "0.65rem", padding: "1px 4px" }}
+                                  title="Remove step"
+                                >
+                                  ✕
+                                </Button>
+                              </div>
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  )}
+                  <div className="d-flex gap-2 mt-2">
+                    <Button size="sm" variant="primary" style={{ fontSize: "0.75rem" }} onClick={handleSaveSteps}>
+                      Save Changes
+                    </Button>
+                    <Button size="sm" variant="outline-secondary" style={{ fontSize: "0.75rem" }} onClick={handleCancelSteps}>
+                      Cancel
+                    </Button>
+                  </div>
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+
+      <style>{`
+        @keyframes pulse {
+          0%, 100% { opacity: 1; }
+          50% { opacity: 0.3; }
+        }
+      `}</style>
+    </div>
+  );
+}
+
+export default AutomationSection;

--- a/src/components/AutomationSection.js
+++ b/src/components/AutomationSection.js
@@ -296,7 +296,7 @@ function AutomationSection() {
                       title="Stop script"
                       style={{ fontSize: "0.75rem", padding: "2px 6px" }}
                     >
-                      ⏹
+                      ■
                     </Button>
                   ) : (
                     <Button

--- a/src/components/AutomationSection.js
+++ b/src/components/AutomationSection.js
@@ -214,12 +214,13 @@ function AutomationSection() {
       )}
 
       {/* Controls */}
-      <div className="d-flex gap-2 mb-3">
+      <div className="d-flex gap-2 mb-2">
         <Button
           size="sm"
           variant="danger"
           disabled={isRecording || isPlaying}
           onClick={handleStartRecording}
+          title="Start Recording (Cmd+Shift+A on Mac / Ctrl+Shift+A on Win/Linux)"
         >
           ⏺ Start Recording
         </Button>
@@ -228,13 +229,10 @@ function AutomationSection() {
           variant="secondary"
           disabled={!isRecording}
           onClick={handleStopRecording}
+          title="Stop Recording (Cmd+Shift+Z on Mac / Ctrl+Shift+Z on Win/Linux)"
         >
           ⏹ Stop Recording
         </Button>
-      </div>
-
-      <div style={{ fontSize: "0.75rem", color: "#6c757d", marginBottom: "0.5rem" }}>
-        Shortcuts: <strong>Cmd+Shift+A</strong> (Mac) / <strong>Ctrl+Shift+A</strong> (Win/Linux) to start, <strong>+Z</strong> to stop.
       </div>
 
       {/* Script list */}
@@ -243,7 +241,7 @@ function AutomationSection() {
           No scripts recorded yet. Press <strong>Start Recording</strong>, perform actions on your device, then press <strong>Stop Recording</strong>.
         </p>
       ) : (
-        <div>
+        <div style={{ maxHeight: "calc(100vh - 265px)", overflowY: "scroll" }}>
           {scripts.map((script) => (
             <div key={script.id} className="mb-2 border rounded" style={{ overflow: "hidden" }}>
               {/* Script header row */}

--- a/src/components/ControlSection.js
+++ b/src/components/ControlSection.js
@@ -101,14 +101,15 @@ function ControlSection({ streamingDevices, onUpdateStreamingDevices, onDeletedD
   };
 
   return (
-    <div className="p-3" style={{ position: "relative" }}>
+    <div className="p-2" style={{ position: "relative", fontSize: "0.85rem" }}>
       <Card>
-        <Card.Body>
+        <Card.Body className="p-2">
           <Form>
             <Form.Group controlId="formIpAddress" className="form-group-spacing">
-              <Row>
+              <Row className="align-items-center">
                 <Col>
                   <Form.Control
+                    size="sm"
                     type="text"
                     placeholder="Enter IP address"
                     value={ipAddress}
@@ -118,11 +119,17 @@ function ControlSection({ streamingDevices, onUpdateStreamingDevices, onDeletedD
                 </Col>
                 <Col>
                   <Form.Control
+                    size="sm"
                     type="text"
                     placeholder="Enter Alias"
                     value={alias}
                     onChange={(e) => setAlias(e.target.value)}
                   />
+                </Col>
+                <Col xs="auto">
+                  <Button size="sm" title="Add Device" variant="primary" onClick={handleAddDevice}>
+                    &#x271A;
+                  </Button>
                 </Col>
               </Row>
             </Form.Group>
@@ -160,11 +167,6 @@ function ControlSection({ streamingDevices, onUpdateStreamingDevices, onDeletedD
                     disabled={!adbPath}
                   />
                 </Col>
-                <Col xs="auto" className="d-flex align-items-center ml-auto">
-                  <Button title="Add Device" variant="primary" onClick={handleAddDevice}>
-                    &#x271A;
-                  </Button>
-                </Col>
               </Row>
             </Form.Group>
             <Form.Group controlId="formDeviceList" className="form-group-spacing">
@@ -189,7 +191,7 @@ function ControlSection({ streamingDevices, onUpdateStreamingDevices, onDeletedD
               <Form.Label>Streaming Device List</Form.Label>
               <Row>
                 <Col className="d-flex align-items-center flex-grow-1">
-                  <Form.Control as="select" value={selectedDevice} onChange={handleDeviceSelect}>
+                  <Form.Control size="sm" as="select" value={selectedDevice} onChange={handleDeviceSelect}>
                     <option value="">Select a device to delete</option>
                     {streamingDevices.map((device, index) => (
                       <option key={index} value={device.id}>
@@ -200,7 +202,7 @@ function ControlSection({ streamingDevices, onUpdateStreamingDevices, onDeletedD
                   </Form.Control>
                 </Col>
                 <Col xs="auto" className="d-flex align-items-center">
-                  <Button title="Delete Device" variant="primary" onClick={handleDeleteDevice}>
+                  <Button size="sm" title="Delete Device" variant="primary" onClick={handleDeleteDevice}>
                     &#x232B;
                   </Button>
                 </Col>
@@ -210,10 +212,10 @@ function ControlSection({ streamingDevices, onUpdateStreamingDevices, onDeletedD
               <Form.Label>ADB Tool Path</Form.Label>
               <Row>
                 <Col className="d-flex align-items-center flex-grow-1">
-                  <Form.Control type="text" readOnly value={adbPath} />
+                  <Form.Control size="sm" type="text" readOnly value={adbPath} />
                 </Col>
                 <Col xs="auto" className="d-flex align-items-center">
-                  <Button title="Select ADB Path" variant="primary" onClick={handleSelectAdbPath}>
+                  <Button size="sm" title="Select ADB Path" variant="primary" onClick={handleSelectAdbPath}>
                     &#x2026;
                   </Button>
                 </Col>
@@ -222,6 +224,15 @@ function ControlSection({ streamingDevices, onUpdateStreamingDevices, onDeletedD
           </Form>
         </Card.Body>
       </Card>
+
+      <Alert variant="warning" className="mt-2 mb-0 p-2" style={{ fontSize: "0.78rem" }}>
+        <strong>Roku users:</strong> To enable ECP (External Control Protocol), follow these steps on your device:
+        <ol className="mb-0 mt-1 ps-3">
+          <li>Go to <strong>Settings &gt; System &gt; Advanced system settings</strong>.</li>
+          <li>Select <strong>Control by mobile apps</strong>.</li>
+          <li>Set to <strong>Enabled</strong> or <strong>Permissive</strong>.</li>
+        </ol>
+      </Alert>
     </div>
   );
 }

--- a/src/components/OverlaySection.js
+++ b/src/components/OverlaySection.js
@@ -240,7 +240,7 @@ function OverlaySection() {
   };
 
   return (
-    <Container className="p-2" style={{ position: "relative" }}>
+    <Container fluid className="p-2" style={{ position: "relative" }}>
       {showAlert && (
         <Alert
           variant="info"

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,7 @@
+html {
+  font-size: 14px;
+}
+
 body {
   margin: 0;
   font-family: 'Roboto', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Oxygen',


### PR DESCRIPTION
## Summary

- **Automation Scripts** — new Automation tab (between Control and Overlay) lets users record keyboard sequences with inter-key timing and replay them on demand. Scripts are persisted in `settings.json` and accessible from the macOS menu bar, system tray, and right-click context menu.
- **Step editor** — each script can be renamed, have its steps reordered, individual step delays edited (0–5000 ms), or individual steps deleted. Playback respects recorded timing and warns if the script was recorded for a different protocol (ECP vs ADB).
- **Keyboard shortcuts** — `Cmd/Ctrl+Shift+A` to start recording, `Cmd/Ctrl+Shift+Z` to stop. Shortcuts shown as button tooltips in the UI.
- **Control tab polish** — font and controls reduced to compact (`sm`) size; Add Device button moved inline with the IP/Alias row; Roku ECP setup instructions added as a warning alert at the bottom.
- **Overlay tab** — container changed to `fluid` so it fills the wider settings window.
- **Settings window** — widened from 630 → 700 px and base font reduced to 14 px to accommodate 7 tabs without wrapping.
- **Docs** — `usage-guide.md` updated with Automation Scripts section and Roku ECP prerequisite callout; `building-from-source.md` updated with Electron v42, all npm scripts, macOS notarization note, and expanded project structure; `README.md` adds Automation Scripts to the features list.

This PR closes #75 

🤖 Generated with [Claude Code](https://claude.com/claude-code)
