### PR TITLE
Add Control Device quick-switch submenu to tray and context menus

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -464,6 +464,56 @@ app.whenReady().then(async () => {
     updateShowDisplayMenuItem(true);
   });
 
+  function switchControlDevice(deviceId) {
+    if (!deviceId) return;
+    settings.control.deviceId = deviceId;
+    // Update linked property so the capture device label in menus reflects the new selection
+    const currentCaptureId = settings.display.deviceId;
+    if (currentCaptureId && settings.control.deviceList) {
+      settings.control.deviceList = settings.control.deviceList.map((device) => {
+        if (device.id === deviceId) {
+          return { ...device, linked: currentCaptureId };
+        } else if (device.linked === currentCaptureId) {
+          return { ...device, linked: "" };
+        }
+        return device;
+      });
+    }
+    saveSettings(settings);
+    const oldControlIp = controlIp;
+    [controlIp, controlType] = deviceId.split("|");
+    if (isADBConnected && oldControlIp !== controlIp) {
+      isADBConnected = disconnectADB();
+    }
+    if (!isADBConnected && controlType === "adb") {
+      isADBConnected = connectADB(controlIp, settings.control?.adbPath);
+    }
+    displayWindow?.webContents?.send("shared-window-channel", {
+      type: "set-control-selected",
+      payload: deviceId,
+    });
+    displayWindow?.webContents?.send("shared-window-channel", {
+      type: "set-control-list",
+      payload: settings.control.deviceList,
+    });
+    mainWindow?.webContents?.send("update-control-device", {
+      deviceId,
+      deviceList: settings.control.deviceList,
+    });
+    const currentTray = getTray();
+    if (currentTray) {
+      createTrayMenu(
+        mainWindow,
+        displayWindow,
+        packageInfo,
+        captureDevices,
+        settings,
+        isCurrentlyRecording,
+        switchControlDevice
+      );
+    }
+  }
+
   ipcMain.on("shared-window-channel", (event, arg) => {
     // Only forward set-video-stream messages if display window is visible or being shown
     // Forward all other messages unconditionally
@@ -508,7 +558,8 @@ app.whenReady().then(async () => {
             packageInfo,
             captureDevices,
             settings,
-            isCurrentlyRecording
+            isCurrentlyRecording,
+            switchControlDevice
           );
         }
       }
@@ -540,7 +591,8 @@ app.whenReady().then(async () => {
             packageInfo,
             captureDevices,
             settings,
-            isCurrentlyRecording
+            isCurrentlyRecording,
+            switchControlDevice
           );
         }
       }
@@ -762,7 +814,8 @@ app.whenReady().then(async () => {
       captureDevices,
       settings,
       isScriptRecording,
-      isScriptPlaying
+      isScriptPlaying,
+      switchControlDevice
     );
     menu.popup({ window: displayWindow });
   });
@@ -1021,7 +1074,7 @@ app.whenReady().then(async () => {
     updateScriptsSubmenu(settings.scripts, mainWindow, displayWindow, packageInfo, settings);
     const tray = getTray();
     if (tray) {
-      createTrayMenu(mainWindow, displayWindow, packageInfo, captureDevices, settings, isCurrentlyRecording);
+      createTrayMenu(mainWindow, displayWindow, packageInfo, captureDevices, settings, isCurrentlyRecording, switchControlDevice);
     }
   });
 

--- a/public/menu.js
+++ b/public/menu.js
@@ -32,6 +32,9 @@ let trayEnableAudioItem = null;
 let trayStartScriptRecordingItem = null;
 let trayStopScriptRecordingItem = null;
 
+// Control device switch callback (stored for reuse across menu rebuilds)
+let _onDeviceSelected = null;
+
 // Context menu variables
 let contextAlwaysOnTopItem = null;
 let contextEnableAudioItem = null;
@@ -482,8 +485,10 @@ function createTrayMenu(
   packageInfo,
   captureDevices = null,
   settings = null,
-  isCurrentlyRecording = false
+  isCurrentlyRecording = false,
+  onDeviceSelected = null
 ) {
+  if (onDeviceSelected) _onDeviceSelected = onDeviceSelected;
   const menuItems = [
     MenuItems.showCarabiner(displayWindow),
     MenuItems.separator(),
@@ -523,6 +528,9 @@ function createTrayMenu(
 
   // Add capture devices menu
   appendCaptureDevicesMenu(trayMenu, mainWindow, captureDevices, settings);
+
+  // Add control device quick-switch submenu
+  appendControlDevicesMenu(trayMenu, _onDeviceSelected, settings);
 
   // Add common menu items
   const commonItems = [
@@ -578,6 +586,26 @@ function appendCaptureDevicesMenu(menu, mainWindow, captureDevices = null, setti
     });
     menu.append(menuItem);
   });
+}
+
+function appendControlDevicesMenu(menu, onDeviceSelected, settings) {
+  const deviceList = settings?.control?.deviceList;
+  if (!deviceList || deviceList.length === 0) return;
+
+  menu.append(new MenuItem({ type: "separator" }));
+  menu.append(
+    new MenuItem({
+      label: "Control Device",
+      submenu: deviceList.map((device) => ({
+        label: device.alias
+          ? `${device.type}: ${device.alias} - ${device.ipAddress}`
+          : `${device.type}: ${device.ipAddress}`,
+        type: "radio",
+        checked: settings?.control?.deviceId === device.id,
+        click: () => onDeviceSelected?.(device.id),
+      })),
+    })
+  );
 }
 
 function updateTrayRecordingMenuItems(isRecording) {
@@ -642,8 +670,10 @@ function createContextMenu(
   captureDevices = null,
   settings = null,
   isScriptRecording = false,
-  isScriptPlaying = false
+  isScriptPlaying = false,
+  onDeviceSelected = null
 ) {
+  if (onDeviceSelected) _onDeviceSelected = onDeviceSelected;
   const menuItems = [
     MenuItems.copyScreenshot(displayWindow),
     MenuItems.saveScreenshot(displayWindow),
@@ -680,6 +710,9 @@ function createContextMenu(
 
   // Add capture devices menu
   appendCaptureDevicesMenu(menu, mainWindow, captureDevices, settings);
+
+  // Add control device quick-switch submenu
+  appendControlDevicesMenu(menu, _onDeviceSelected, settings);
 
   // Add remaining menu items
   const additionalItems = [
@@ -820,6 +853,7 @@ module.exports = {
   updateScriptsSubmenu,
   createTrayMenu,
   appendCaptureDevicesMenu,
+  appendControlDevicesMenu,
   updateTrayRecordingMenuItems,
   toggleDockIcon,
   createContextMenu,

--- a/src/App.js
+++ b/src/App.js
@@ -29,6 +29,14 @@ function App() {
   const onDeletedDeviceRef = useRef(null);
 
   useEffect(() => {
+    electronAPI.onMessageReceived("update-control-device", (event, data) => {
+      if (data?.deviceList) {
+        setStreamingDevices(data.deviceList);
+      }
+    });
+  }, []);
+
+  useEffect(() => {
     // Load initial settings from main process
     electronAPI.invoke("load-settings").then((settings) => {
       if (settings.control && settings.control.deviceList) {

--- a/src/components/GeneralSection.js
+++ b/src/components/GeneralSection.js
@@ -100,10 +100,17 @@ function GeneralSection({ streamingDevices, onUpdateStreamingDevices, onDeletedD
       notifyControlChange("set-control-selected", currentLinked);
     });
 
+    window.electronAPI.onMessageReceived("update-control-device", (event, data) => {
+      const deviceId = typeof data === "string" ? data : data?.deviceId;
+      currentLinked = deviceId ?? "";
+      setLinkedDevice(deviceId ?? "");
+    });
+
     return () => {
       window.electronAPI.removeListener("open-display-tab");
       window.electronAPI.removeListener("update-audio-enabled");
       window.electronAPI.removeListener("update-capture-device");
+      window.electronAPI.removeListener("update-control-device");
     };
   }, []);
 


### PR DESCRIPTION
Adds a "Control Device" submenu to both the tray and right-click popup menus so users can switch the active streaming device without opening Settings. Switching also updates the linked capture device label in the menu and keeps the General tab dropdown in sync.

This PR closes #73 