### PR TITLE
Add Show Key Presses overlay feature for live presentations

### DIFF
--- a/public/display.html
+++ b/public/display.html
@@ -76,6 +76,35 @@
             .toastify {
                 -webkit-app-region: no-drag;
             }
+            #key-overlay {
+                position: fixed;
+                bottom: 110px;
+                left: 50%;
+                width: 0;
+                height: 0;
+                z-index: 2000;
+                pointer-events: none;
+            }
+            @keyframes key-float {
+                0%   { opacity: 1; transform: translateX(-50%) translateY(0)     scale(1);   }
+                10%  { opacity: 1;                                                            }
+                100% { opacity: 0; transform: translateX(-50%) translateY(-80vh) scale(0.7); }
+            }
+            .key-indicator {
+                position: absolute;
+                left: 0;
+                bottom: 0;
+                white-space: nowrap;
+                background: rgba(0, 0, 0, 0.72);
+                color: #fff;
+                border: 2px solid rgba(255, 255, 255, 0.45);
+                border-radius: 10px;
+                padding: 8px 18px;
+                font-size: 26px;
+                font-weight: bold;
+                font-family: monospace;
+                animation: key-float 1.5s ease-out forwards;
+            }
         </style>
         <link href="../node_modules/toastify-js/src/toastify.css" rel="stylesheet" />
     </head>
@@ -128,6 +157,7 @@
             title="Show Settings"
         >⋯</button>
         <div id="device-label" style="opacity: 0"></div>
+        <div id="key-overlay"></div>
         <script src="../node_modules/toastify-js/src/toastify.js"></script>
         <script src="render.js"></script>
     </body>

--- a/public/main.js
+++ b/public/main.js
@@ -676,6 +676,9 @@ app.whenReady().then(async () => {
     } else if (arg.type && arg.type === "set-audio-enabled") {
       settings.display.audioEnabled = arg.payload;
       saveFlag = true;
+    } else if (arg.type && arg.type === "set-show-keystrokes") {
+      settings.display.showKeystrokes = arg.payload;
+      saveFlag = true;
     } else if (arg.type && arg.type === "clear-overlay-image") {
       saveFlag = false;
       // Clear the overlay image by sending a specific clear message

--- a/public/render.js
+++ b/public/render.js
@@ -44,6 +44,65 @@ let isRecording = false;
 // Device monitoring variables
 let currentDeviceList = [];
 
+// Key press overlay variables
+let showKeystrokes = false;
+const MAX_KEY_INDICATORS = 3;
+let activeKeyIndicators = [];
+
+const ECP_DISPLAY_NAMES = {
+  up: "Up", down: "Down", left: "Left", right: "Right",
+  select: "OK", back: "Back", home: "Home",
+  play: "Play", pause: "Pause", playpause: "Play/Pause",
+  fwd: "Fwd", rev: "Rev", replay: "Replay", instantreplay: "Replay",
+  info: "*", search: "Search", backspace: "⌫", enter: "Enter",
+  volumeup: "Vol+", volumedown: "Vol-", volumemute: "Mute",
+  channelup: "Ch+", channeldown: "Ch-", findremote: "Find Remote",
+  poweroff: "Power", a: "A", b: "B", c: "C", d: "D",
+};
+
+const ADB_DISPLAY_NAMES = {
+  "3": "Home", "4": "Back",
+  "19": "Up", "20": "Down", "21": "Left", "22": "Right",
+  "66": "OK", "67": "⌫",
+  "85": "Play", "86": "Stop", "87": "Next", "88": "Prev",
+  "89": "Rev", "90": "Fwd",
+  "91": "Vol+", "92": "Vol-", "164": "Mute",
+  "1": "Menu",
+};
+
+function formatDeviceKeyLabel(key, type) {
+  if (type === "ecp") {
+    return ECP_DISPLAY_NAMES[key.toLowerCase()] || key.charAt(0).toUpperCase() + key.slice(1);
+  }
+  // ADB: numeric keycodes → readable name
+  if (ADB_DISPLAY_NAMES[key]) return ADB_DISPLAY_NAMES[key];
+  const code = parseInt(key, 10);
+  if (!isNaN(code)) {
+    if (code >= 29 && code <= 54) return String.fromCharCode(code + 36); // A–Z
+    if (code >= 7 && code <= 16) return String(code - 7); // 0–9
+  }
+  // Non-numeric ADB value (e.g. special chars like "\\<")
+  return key.replace(/^\\/, "");
+}
+
+function displayKeyIndicator(label) {
+  const overlay = document.getElementById("key-overlay");
+  if (!overlay) return;
+  if (activeKeyIndicators.length >= MAX_KEY_INDICATORS) {
+    const oldest = activeKeyIndicators.shift();
+    oldest.remove();
+  }
+  const el = document.createElement("div");
+  el.className = "key-indicator";
+  el.textContent = label;
+  overlay.appendChild(el);
+  activeKeyIndicators.push(el);
+  el.addEventListener("animationend", () => {
+    el.remove();
+    activeKeyIndicators = activeKeyIndicators.filter((x) => x !== el);
+  });
+}
+
 // Script recording/playback variables
 let isScriptRecording = false;
 let currentScriptSteps = [];
@@ -61,6 +120,9 @@ window.electronAPI.invoke("load-settings").then(async (settings) => {
   if (settings.display && settings.display.audioEnabled !== undefined) {
     audioEnabled = settings.display.audioEnabled;
     // Note: updateAudioConstraints() will be called when video stream is set
+  }
+  if (settings.display && settings.display.showKeystrokes !== undefined) {
+    showKeystrokes = settings.display.showKeystrokes;
   }
 });
 
@@ -215,6 +277,7 @@ const eventHandlers = {
   "set-control-selected": handleControlSelected,
   "set-overlay-opacity": handleOverlayOpacity,
   "set-audio-enabled": handleSetAudioEnabled,
+  "set-show-keystrokes": (payload) => { showKeystrokes = payload; },
 };
 
 function renderDisplay(constraints, isBlankRetry = false) {
@@ -622,12 +685,14 @@ window.addEventListener("DOMContentLoaded", function () {
     if (controlType === "ecp") {
       const key = ecpKeysMap.get(keyCode);
       if (key && key.toLowerCase() !== "ignore") {
+        if (mod === 0 && showKeystrokes) displayKeyIndicator(formatDeviceKeyLabel(key, "ecp"));
         recordScriptStep(key, mod);
         sendKey(key, mod);
       } else if (
         !["Alt", "Control", "Meta", "Shift", "Tab", "Dead"].includes(event.key) &&
         mod === 0
       ) {
+        if (showKeystrokes) displayKeyIndicator(event.key.toUpperCase());
         const litKey = `lit_${encodeURIComponent(event.key)}`;
         recordScriptStep(litKey, -1);
         sendKey(litKey, -1);
@@ -635,6 +700,7 @@ window.addEventListener("DOMContentLoaded", function () {
     } else if (controlType === "adb") {
       const key = adbKeysMap.get(keyCode);
       if (key) {
+        if (mod === 0 && showKeystrokes) displayKeyIndicator(formatDeviceKeyLabel(key, "adb"));
         recordScriptStep(key, mod);
         sendKey(key, mod);
       }

--- a/public/settings.js
+++ b/public/settings.js
@@ -22,6 +22,7 @@ function loadSettings() {
     display: {
       showInDock: true, // macOS: true = dock mode, false = menubar mode
       autoUpdate: true, // Check for updates enabled by default
+      showKeystrokes: false,
     },
     border: {},
     control: {

--- a/src/components/DisplaySection.js
+++ b/src/components/DisplaySection.js
@@ -58,6 +58,7 @@ function DisplaySection() {
   const [displaySize, setDisplaySize] = useState("custom"); // Default fallback
   const [transparency, setTransparency] = useState(0);
   const [alwaysOnTop, setAlwaysOnTop] = useState(true);
+  const [showKeystrokes, setShowKeystrokes] = useState(false);
   const [mainDisplaySize, setMainDisplaySize] = useState({
     width: 1920,
     height: 1080,
@@ -99,6 +100,9 @@ function DisplaySection() {
         }
         if (settings.display && settings.display.alwaysOnTop !== undefined) {
           setAlwaysOnTop(settings.display.alwaysOnTop);
+        }
+        if (settings.display && settings.display.showKeystrokes !== undefined) {
+          setShowKeystrokes(settings.display.showKeystrokes);
         }
 
         // Set display size based on current window size and filtered predefined options
@@ -177,6 +181,14 @@ function DisplaySection() {
   const handleAlwaysOnTopChange = (e) => {
     setAlwaysOnTop(e.target.checked);
     electronAPI.send("save-always-on-top", e.target.checked);
+  };
+
+  const handleShowKeystrokesChange = (e) => {
+    setShowKeystrokes(e.target.checked);
+    electronAPI.sendSync("shared-window-channel", {
+      type: "set-show-keystrokes",
+      payload: e.target.checked,
+    });
   };
 
   const handleResolutionChange = (e) => {
@@ -271,6 +283,13 @@ function DisplaySection() {
                     checked={alwaysOnTop}
                     onChange={handleAlwaysOnTopChange}
                     className="text-nowrap"
+                  />
+                  <Form.Check
+                    type="checkbox"
+                    label="Show Key Presses"
+                    checked={showKeystrokes}
+                    onChange={handleShowKeystrokesChange}
+                    className="text-nowrap mt-2"
                   />
                 </div>
               </div>


### PR DESCRIPTION
## Summary

- Adds a **Show Key Presses** toggle in Settings → Display tab (disabled by default)
- When enabled, the remote control key name floats up from the bottom-center of the display window and fades out, arcade-style — up to 3 keys visible simultaneously at different animation stages
- Labels show the **device key name**, not the keyboard key: `Up`, `Select`, `Back`, `Play`, `Fwd`, `Mute`, etc. for both ECP (Roku) and ADB (Android/Fire TV/Google TV)
- Designed for presenters broadcasting video who want the audience to see what remote keys are being pressed

## Changes

| File | Change |
|---|---|
| `public/settings.js` | Added `showKeystrokes: false` default |
| `public/display.html` | Added `#key-overlay` container + `@keyframes key-float` + `.key-indicator` CSS |
| `public/render.js` | Added `ECP_DISPLAY_NAMES`, `ADB_DISPLAY_NAMES`, `formatDeviceKeyLabel`, `displayKeyIndicator`; hooked into `handleKeyboardEvent` and `eventHandlers` map |
| `public/main.js` | Handles `set-show-keystrokes` in the `shared-window-channel` IPC handler |
| `src/components/DisplaySection.js` | Added `showKeystrokes` state, loads from settings, sends via `shared-window-channel`, renders checkbox |

## Test plan

- [ ] Open Settings → Display tab — **Show Key Presses** checkbox is unchecked by default
- [ ] Enable the checkbox, focus the display window, press arrow keys and Enter — floating labels appear (`Up`, `Down`, `Select`, etc.)
- [ ] Press 3 keys quickly — up to 3 labels visible simultaneously at different heights/opacities
- [ ] Uncheck — no more labels appear
- [ ] Restart the app — setting persists correctly
- [ ] Test with an ADB device — labels show `Up`, `OK`, `Back`, etc. instead of raw keycodes

🤖 Generated with [Claude Code](https://claude.com/claude-code)