### PR TITLE
Add script recording/playback indicators and menu controls

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -94,7 +94,7 @@ Key message types handled in `main.js`:
 - `set-show-keystrokes` — toggles the on-screen key indicator overlay
 
 Separate `ipcMain.on`/`ipcMain.handle` channels (outside `shared-window-channel`) handle:
-- Script recording lifecycle: `start-script-recording`, `stop-script-recording`, `save-script`, `run-script`, `stop-script`, `script-playback-done`
+- Script recording lifecycle: `start-script-recording`, `stop-script-recording`, `save-script`, `run-script`, `stop-script`, `script-playback-started`, `script-playback-done`
 - Script management: `get-scripts`, `update-script-name`, `update-script-steps`, `delete-script`
 - File dialogs: `save-screenshot-dialog`, `save-video-dialog`, `select-adb-path`, `select-atv-path`, `load-image`, `load-image-by-path`
 - Settings persistence: `save-shortcut`, `save-launch-app-at-login`, `save-always-on-top`, `save-dark-mode`, etc.
@@ -110,9 +110,10 @@ The device ID string format encodes protocol: `"<ip>|ecp"`, `"<ip>|adb"`, or `"<
 ### Automation / Script System
 
 - **Recording**: `render.js` intercepts key events during recording and logs steps (key, delay, device type). When stopped, sends the step array to main via `save-script`.
-- **Playback**: main forwards a `play-script` message with `{id, steps}` to `render.js`; `playScript()` replays each step with its recorded delay. Cancellable via `stop-script`.
+- **Playback**: all playback is routed through main's `run-script` handler (including menu/tray quick-launch), which tracks `isScriptPlaying`, sends `script-playback-started` to `mainWindow` (so the Automation tab flips ▶ to ■), and forwards `play-script` with `{id, steps, controlType}` to `render.js`; `playScript()` replays each step with its recorded delay. Cancellable via `stop-script`; completion is reported via `script-playback-done`.
 - **Storage**: scripts are saved in `settings.scripts[]` (persisted to `settings.json`). CRUD is handled by dedicated `ipcMain` channels (`get-scripts`, `update-script-name`, `update-script-steps`, `delete-script`).
-- **Menu integration**: `menu.js` builds an Automation submenu in both tray and context menus listing all saved scripts for quick launch.
+- **Menu integration**: `menu.js` builds a "Run Script" submenu and a "Stop Script" item in the app/tray/context menus. `updateScriptRecordingMenuItems(disableStart, isRecording, isPlaying)` keeps them in sync: "Run Script" is disabled while recording or playing, and "Stop Script" is enabled only while playing.
+- **Status indicators**: the display window shows top-left overlay indicators that share one anchor and reflow horizontally in activation order — red (video recording), blue (script recording), green ▶ (script playback). Managed by `toggleIndicator()` in `render.js`.
 
 ### Show Keystrokes Overlay
 

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -105,14 +105,17 @@ The **Automation** tab lets you record key sequences (with the exact timing betw
 
 1. Open the **Automation** tab in settings.
 2. Click **Start Recording** (or press `Cmd+Shift+A` on macOS / `Ctrl+Shift+A` on Windows/Linux).
-3. Switch focus to the display window and press the keys you want to record. Each keypress is captured along with the delay since the previous key.
+3. Switch focus to the display window and press the keys you want to record. Each keypress is captured along with the delay since the previous key. A **pulsing blue dot** appears in the top-left of the display window while recording is in progress.
 4. Press **Stop Recording** (or `Cmd+Shift+Z` / `Ctrl+Shift+Z`) when done. The script is saved automatically.
 
 **Playing back a script:**
 
 - Click the **▶** button next to any script in the list, or
 - Use the **File → Run Script** submenu (also available in the tray and right-click context menu).
-- Click the **■** button to interrupt playback.
+- While a script runs, a **pulsing green ▶** appears in the top-left of the display window, and the **Run Script** menu is disabled so you can't start a second script over a running one.
+- Stop playback by clicking the **■** button in the Automation tab, or by choosing **Stop Script** from the File menu, tray, or right-click context menu. The tab's **▶** button automatically switches to **■** whenever a script is running — even when it was started from a menu.
+
+> **💡 Tip**: The top-left indicators share a single anchor and line up side by side — for example, recording a video (red dot) while running a script (green ▶) shows both at once.
 
 **Editing a script:**
 

--- a/public/display.html
+++ b/public/display.html
@@ -41,6 +41,13 @@
             .recording-active {
                 animation: recording-pulse 2s infinite !important;
             }
+            @keyframes playback-pulse {
+                0%, 100% { opacity: 0.45; transform: scale(1); }
+                50%      { opacity: 1;    transform: scale(1.15); }
+            }
+            .playback-active {
+                animation: playback-pulse 1.2s infinite !important;
+            }
             @keyframes spin {
                 to { transform: rotate(360deg); }
             }
@@ -135,21 +142,51 @@
             <div id="reconnecting-label">Reconnecting capture device...</div>
         </div>
         <div
-            id="recording-indicator"
+            id="indicator-bar"
             style="
                 position: fixed;
                 top: 25px;
                 left: 30px;
-                width: 12px;
-                height: 12px;
-                background-color: #ff4444;
-                border-radius: 50%;
-                opacity: 0;
-                transition: opacity 0.3s;
+                display: flex;
+                align-items: center;
+                gap: 10px;
                 z-index: 1001;
-                box-shadow: 0 0 8px rgba(255, 68, 68, 0.6);
+                pointer-events: none;
             "
-        ></div>
+        >
+            <div
+                id="recording-indicator"
+                style="
+                    display: none;
+                    width: 12px;
+                    height: 12px;
+                    background-color: #ff4444;
+                    border-radius: 50%;
+                    box-shadow: 0 0 8px rgba(255, 68, 68, 0.6);
+                "
+            ></div>
+            <div
+                id="script-recording-indicator"
+                style="
+                    display: none;
+                    width: 12px;
+                    height: 12px;
+                    background-color: #4488ff;
+                    border-radius: 50%;
+                    box-shadow: 0 0 8px rgba(68, 136, 255, 0.6);
+                "
+            ></div>
+            <div
+                id="script-playback-indicator"
+                style="
+                    display: none;
+                    color: #44dd66;
+                    font-size: 14px;
+                    line-height: 1;
+                    text-shadow: 0 0 8px rgba(68, 221, 102, 0.7);
+                "
+            >&#9654;</div>
+        </div>
         <button
             id="settings-button"
             style="opacity: 0"

--- a/public/main.js
+++ b/public/main.js
@@ -466,7 +466,7 @@ app.whenReady().then(async () => {
     updateShowDisplayMenuItem(false);
     if (isScriptRecording) {
       isScriptRecording = false;
-      updateScriptRecordingMenuItems(false, false);
+      updateScriptRecordingMenuItems(isScriptRecording || isScriptPlaying, isScriptRecording, isScriptPlaying);
     }
   });
 
@@ -475,7 +475,7 @@ app.whenReady().then(async () => {
     updateShowDisplayMenuItem(false);
     if (isScriptRecording) {
       isScriptRecording = false;
-      updateScriptRecordingMenuItems(false, false);
+      updateScriptRecordingMenuItems(isScriptRecording || isScriptPlaying, isScriptRecording, isScriptPlaying);
     }
   });
 
@@ -1098,7 +1098,7 @@ app.whenReady().then(async () => {
     if (!isScriptRecording) {
       if (displayWindow && !displayWindow.isVisible()) displayWindow.show();
       isScriptRecording = true;
-      updateScriptRecordingMenuItems(true, true);
+      updateScriptRecordingMenuItems(isScriptRecording || isScriptPlaying, isScriptRecording, isScriptPlaying);
       mainWindow?.webContents.send("script-recording-state-changed", true);
       displayWindow?.webContents.send("start-script-recording");
     }
@@ -1112,7 +1112,7 @@ app.whenReady().then(async () => {
 
   ipcMain.on("script-recording-state-changed", (event, recording) => {
     isScriptRecording = recording;
-    updateScriptRecordingMenuItems(recording, recording);
+    updateScriptRecordingMenuItems(isScriptRecording || isScriptPlaying, isScriptRecording, isScriptPlaying);
     mainWindow?.webContents.send("script-recording-state-changed", recording);
   });
 
@@ -1122,7 +1122,7 @@ app.whenReady().then(async () => {
     settings.scripts.push(script);
     saveSettings(settings);
     isScriptRecording = false;
-    updateScriptRecordingMenuItems(false, false);
+    updateScriptRecordingMenuItems(isScriptRecording || isScriptPlaying, isScriptRecording, isScriptPlaying);
     mainWindow?.webContents.send("script-recording-state-changed", false);
     mainWindow?.webContents.send("shared-window-channel", {
       type: "scripts-updated",
@@ -1136,11 +1136,14 @@ app.whenReady().then(async () => {
   });
 
   ipcMain.on("run-script", (event, scriptId) => {
+    if (isScriptRecording || isScriptPlaying) return;
     const script = settings.scripts?.find((s) => s.id === scriptId);
     if (script) {
       if (displayWindow && !displayWindow.isVisible()) displayWindow.show();
       isScriptPlaying = true;
-      updateScriptRecordingMenuItems(isScriptRecording || isScriptPlaying, isScriptRecording);
+      updateScriptRecordingMenuItems(isScriptRecording || isScriptPlaying, isScriptRecording, isScriptPlaying);
+      // Notify the settings window so the Automation tab reflects the running script
+      mainWindow?.webContents.send("script-playback-started", script.id);
       displayWindow?.webContents.send("play-script", {
         id: script.id,
         steps: script.steps,
@@ -1155,7 +1158,7 @@ app.whenReady().then(async () => {
 
   ipcMain.on("script-playback-done", (event, scriptId) => {
     isScriptPlaying = false;
-    updateScriptRecordingMenuItems(isScriptRecording, isScriptRecording);
+    updateScriptRecordingMenuItems(isScriptRecording || isScriptPlaying, isScriptRecording, isScriptPlaying);
     mainWindow?.webContents.send("script-playback-done", scriptId);
   });
 

--- a/public/menu.js
+++ b/public/menu.js
@@ -21,6 +21,10 @@ let enableAudioMenuItem;
 // Script recording menu item references
 let startScriptRecordingMenuItem = null;
 let stopScriptRecordingMenuItem = null;
+let scriptsSubmenuItem = null;
+let trayScriptsSubmenuItem = null;
+let stopScriptMenuItem = null;
+let trayStopScriptItem = null;
 
 // Tray-related variables
 let tray = null;
@@ -212,21 +216,30 @@ const MenuItems = {
     },
   }),
 
-  scriptsSubmenu: (scripts, displayWindow) => ({
+  scriptsSubmenu: (scripts, displayWindow, enabled = true) => ({
     label: "Run Script",
-    enabled: scripts && scripts.length > 0,
+    enabled: !!(enabled && scripts && scripts.length > 0),
     submenu:
       scripts && scripts.length > 0
         ? scripts.map((s) => ({
             label: s.name,
-            click: () =>
-              displayWindow?.webContents.send("play-script", {
-                id: s.id,
-                steps: s.steps,
-                controlType: s.controlType,
-              }),
+            click: () => {
+              // Route through main's run-script handler so playback state is tracked
+              const { ipcMain } = require("electron");
+              ipcMain.emit("run-script", null, s.id);
+            },
           }))
         : [{ label: "No scripts saved", enabled: false }],
+  }),
+
+  stopScript: (enabled = false) => ({
+    id: "stop-script",
+    label: "Stop Script",
+    enabled,
+    click: () => {
+      const { ipcMain } = require("electron");
+      ipcMain.emit("stop-script");
+    },
   }),
 };
 
@@ -315,7 +328,8 @@ function createMacOSMenu(mainWindow, displayWindow, packageInfo, settings) {
         MenuItems.startScriptRecording(mainWindow, true),
         MenuItems.stopScriptRecording(mainWindow, false),
         MenuItems.separator(),
-        MenuItems.scriptsSubmenu(scripts, displayWindow),
+        { ...MenuItems.scriptsSubmenu(scripts, displayWindow), id: "scripts-submenu" },
+        { ...MenuItems.stopScript(false), id: "stop-script" },
         MenuItems.separator(),
         AppMenuItems.closeWindow(settings),
       ],
@@ -373,6 +387,8 @@ function createMacOSMenu(mainWindow, displayWindow, packageInfo, settings) {
   enableAudioMenuItem = menu.getMenuItemById("enable-audio");
   startScriptRecordingMenuItem = menu.getMenuItemById("start-script-recording");
   stopScriptRecordingMenuItem = menu.getMenuItemById("stop-script-recording");
+  scriptsSubmenuItem = menu.getMenuItemById("scripts-submenu");
+  stopScriptMenuItem = menu.getMenuItemById("stop-script");
 }
 
 function updateAlwaysOnTopMenuItem(value) {
@@ -423,11 +439,18 @@ function updateShowDisplayMenuItem(isVisible) {
   }
 }
 
-function updateScriptRecordingMenuItems(disableStart, isRecording) {
+function updateScriptRecordingMenuItems(disableStart, isRecording, isPlaying = false) {
   if (startScriptRecordingMenuItem) startScriptRecordingMenuItem.enabled = !disableStart;
   if (stopScriptRecordingMenuItem) stopScriptRecordingMenuItem.enabled = !!isRecording;
   if (trayStartScriptRecordingItem) trayStartScriptRecordingItem.enabled = !disableStart;
   if (trayStopScriptRecordingItem) trayStopScriptRecordingItem.enabled = !!isRecording;
+  // Disable "Run Script" while recording OR playing (only re-enable if scripts exist)
+  const hasScripts = !!(_storedSettings && _storedSettings.scripts && _storedSettings.scripts.length > 0);
+  if (scriptsSubmenuItem) scriptsSubmenuItem.enabled = !disableStart && hasScripts;
+  if (trayScriptsSubmenuItem) trayScriptsSubmenuItem.enabled = !disableStart && hasScripts;
+  // Enable "Stop Script" only while a script is playing
+  if (stopScriptMenuItem) stopScriptMenuItem.enabled = !!isPlaying;
+  if (trayStopScriptItem) trayStopScriptItem.enabled = !!isPlaying;
 }
 
 function updateScriptsSubmenu(scripts, mainWindow, displayWindow, packageInfo, settings) {
@@ -489,6 +512,7 @@ function createTrayMenu(
   onDeviceSelected = null
 ) {
   if (onDeviceSelected) _onDeviceSelected = onDeviceSelected;
+  if (settings) _storedSettings = settings;
   const menuItems = [
     MenuItems.showCarabiner(displayWindow),
     MenuItems.separator(),
@@ -511,6 +535,7 @@ function createTrayMenu(
     },
     MenuItems.separator(),
     { ...MenuItems.scriptsSubmenu(settings?.scripts || [], displayWindow), id: "tray-scripts-submenu" },
+    { ...MenuItems.stopScript(false), id: "tray-stop-script" },
     MenuItems.separator(),
     {
       ...MenuItems.alwaysOnTop(displayWindow, mainWindow),
@@ -557,6 +582,8 @@ function createTrayMenu(
   trayEnableAudioItem = trayContextMenu.getMenuItemById("tray-enable-audio");
   trayStartScriptRecordingItem = trayContextMenu.getMenuItemById("tray-start-script-recording");
   trayStopScriptRecordingItem = trayContextMenu.getMenuItemById("tray-stop-script-recording");
+  trayScriptsSubmenuItem = trayContextMenu.getMenuItemById("tray-scripts-submenu");
+  trayStopScriptItem = trayContextMenu.getMenuItemById("tray-stop-script");
   updateTrayRecordingMenuItems(isCurrentlyRecording);
 
   // Set the context menu for the tray
@@ -687,7 +714,8 @@ function createContextMenu(
     { ...MenuItems.startScriptRecording(mainWindow, !(isScriptRecording || isScriptPlaying)), id: "ctx-start-script-recording" },
     { ...MenuItems.stopScriptRecording(mainWindow, isScriptRecording), id: "ctx-stop-script-recording" },
     MenuItems.separator(),
-    MenuItems.scriptsSubmenu(settings?.scripts || [], displayWindow),
+    MenuItems.scriptsSubmenu(settings?.scripts || [], displayWindow, !(isScriptRecording || isScriptPlaying)),
+    { ...MenuItems.stopScript(isScriptPlaying), id: "ctx-stop-script" },
     MenuItems.separator(),
     MenuItems.pasteText(displayWindow),
     MenuItems.separator(),

--- a/public/render.js
+++ b/public/render.js
@@ -13,7 +13,37 @@ const reconnectingOverlay = document.getElementById("reconnecting-overlay");
 const settingsButton = document.getElementById("settings-button");
 const deviceLabel = document.getElementById("device-label");
 const recordingIndicator = document.getElementById("recording-indicator");
+const scriptRecordingIndicator = document.getElementById("script-recording-indicator");
+const scriptPlaybackIndicator = document.getElementById("script-playback-indicator");
 const isMacOS = navigator.platform.toUpperCase().indexOf("MAC") >= 0;
+
+// Indicators share a single anchor (top-left) and reflow left-to-right in the
+// order they were activated, so whichever turned on first sits at the anchor and
+// later ones appear to its right. When an earlier one ends, the rest shift back.
+let indicatorOrderSeq = 0;
+
+function toggleIndicator(el, animClass, on) {
+  if (on) {
+    el.style.order = String(++indicatorOrderSeq);
+    el.classList.add(animClass);
+    el.style.display = "block";
+  } else {
+    el.style.display = "none";
+    el.classList.remove(animClass);
+  }
+}
+
+function setVideoRecordingIndicator(on) {
+  toggleIndicator(recordingIndicator, "recording-active", on);
+}
+
+function setScriptRecordingIndicator(on) {
+  toggleIndicator(scriptRecordingIndicator, "recording-active", on);
+}
+
+function setScriptPlaybackIndicator(on) {
+  toggleIndicator(scriptPlaybackIndicator, "playback-active", on);
+}
 
 function showReconnectingOverlay() {
   reconnectingOverlay.style.display = "flex";
@@ -467,6 +497,7 @@ window.addEventListener("DOMContentLoaded", function () {
     }
     if (isScriptRecording) {
       isScriptRecording = false;
+      setScriptRecordingIndicator(false);
       currentScriptSteps = [];
       currentScriptId = null;
       window.electronAPI.send("script-recording-state-changed", false);
@@ -481,6 +512,7 @@ window.addEventListener("DOMContentLoaded", function () {
     }
     if (isScriptRecording) {
       isScriptRecording = false;
+      setScriptRecordingIndicator(false);
       currentScriptSteps = [];
       currentScriptId = null;
       window.electronAPI.send("script-recording-state-changed", false);
@@ -549,6 +581,7 @@ window.addEventListener("DOMContentLoaded", function () {
     currentScriptControlType = controlType;
     currentScriptId = Date.now().toString(36) + Math.random().toString(36).slice(2);
     lastKeyTimestamp = Date.now();
+    setScriptRecordingIndicator(true);
     window.electronAPI.send("script-recording-state-changed", true);
     showToast("Script recording started...");
   });
@@ -556,6 +589,7 @@ window.addEventListener("DOMContentLoaded", function () {
   window.electronAPI.onMessageReceived("stop-script-recording", () => {
     if (!isScriptRecording) return;
     isScriptRecording = false;
+    setScriptRecordingIndicator(false);
     if (currentScriptSteps.length === 0) {
       showToast("Script has no steps. Recording discarded.", 3000, true);
       currentScriptId = null;
@@ -585,6 +619,7 @@ window.addEventListener("DOMContentLoaded", function () {
 
   window.electronAPI.onMessageReceived("discard-script-recording", () => {
     isScriptRecording = false;
+    setScriptRecordingIndicator(false);
     currentScriptSteps = [];
     currentScriptId = null;
     window.electronAPI.send("script-recording-state-changed", false);
@@ -903,23 +938,20 @@ window.addEventListener("DOMContentLoaded", function () {
         console.error("[Carabiner] MediaRecorder error:", event.error);
         showToast("Recording error occurred!", 5000, true);
         isRecording = false;
-        recordingIndicator.style.opacity = "0"; // Hide recording indicator on error
-        recordingIndicator.classList.remove("recording-active"); // Stop pulsing animation on error
+        setVideoRecordingIndicator(false); // Hide recording indicator on error
         window.electronAPI.send("recording-state-changed", isRecording);
       };
 
       mediaRecorder.start();
       isRecording = true;
-      recordingIndicator.style.opacity = "1"; // Show recording indicator
-      recordingIndicator.classList.add("recording-active"); // Start pulsing animation
+      setVideoRecordingIndicator(true); // Show recording indicator
       window.electronAPI.send("recording-state-changed", isRecording);
       showToast("Recording started...");
     } catch (error) {
       console.error("[Carabiner] Error starting recording:", error);
       showToast("Failed to start recording!", 5000, true);
       isRecording = false;
-      recordingIndicator.style.opacity = "0"; // Hide recording indicator on error
-      recordingIndicator.classList.remove("recording-active"); // Stop pulsing animation on error
+      setVideoRecordingIndicator(false); // Hide recording indicator on error
       window.electronAPI.send("recording-state-changed", isRecording);
     }
   }
@@ -933,15 +965,13 @@ window.addEventListener("DOMContentLoaded", function () {
     try {
       mediaRecorder.stop();
       isRecording = false;
-      recordingIndicator.style.opacity = "0"; // Hide recording indicator
-      recordingIndicator.classList.remove("recording-active"); // Stop pulsing animation
+      setVideoRecordingIndicator(false); // Hide recording indicator
       window.electronAPI.send("recording-state-changed", isRecording);
     } catch (error) {
       console.error("[Carabiner] Error stopping recording:", error);
       showToast("Error stopping recording!", 5000, true);
       isRecording = false;
-      recordingIndicator.style.opacity = "0"; // Hide recording indicator on error
-      recordingIndicator.classList.remove("recording-active"); // Stop pulsing animation on error
+      setVideoRecordingIndicator(false); // Hide recording indicator on error
       window.electronAPI.send("recording-state-changed", isRecording);
     }
   }
@@ -1409,16 +1439,21 @@ async function playScript(steps, scriptControlType) {
   }
   isPlayingScript = true;
   scriptPlaybackCancelled = false;
-  for (let i = 0; i < steps.length; i++) {
-    if (scriptPlaybackCancelled) break;
-    if (i > 0 && steps[i].delay > 0) {
-      await new Promise((resolve) => setTimeout(resolve, Math.min(steps[i].delay, 5000)));
+  setScriptPlaybackIndicator(true);
+  try {
+    for (let i = 0; i < steps.length; i++) {
+      if (scriptPlaybackCancelled) break;
+      if (i > 0 && steps[i].delay > 0) {
+        await new Promise((resolve) => setTimeout(resolve, Math.min(steps[i].delay, 5000)));
+      }
+      if (scriptPlaybackCancelled) break;
+      sendKey(steps[i].key, steps[i].mod);
     }
-    if (scriptPlaybackCancelled) break;
-    sendKey(steps[i].key, steps[i].mod);
+  } finally {
+    isPlayingScript = false;
+    scriptPlaybackCancelled = false;
+    setScriptPlaybackIndicator(false);
   }
-  isPlayingScript = false;
-  scriptPlaybackCancelled = false;
 }
 
 function sendKey(key, mod) {

--- a/src/components/AutomationSection.js
+++ b/src/components/AutomationSection.js
@@ -99,6 +99,11 @@ function AutomationSection() {
     };
     electronAPI.onMessageReceived("script-recording-state-changed", handleRecordingState);
 
+    const handlePlaybackStarted = (_, scriptId) => {
+      setPlayingId(scriptId);
+    };
+    electronAPI.onMessageReceived("script-playback-started", handlePlaybackStarted);
+
     const handlePlaybackDone = (_, scriptId) => {
       setPlayingId((prev) => (prev === scriptId ? null : prev));
     };


### PR DESCRIPTION
## Summary

Adds visual feedback and menu controls for the automation **script** system, mirroring the existing pulsing-red video-recording indicator.

### Indicators (display window)
- 🔵 **Pulsing blue dot** while a script is being **recorded**
- 🟢 **Pulsing green ▶** while a script is **running**
- All indicators (red video / blue script-rec / green playback) now share a **single top-left anchor** and reflow left-to-right in **activation order** — whichever turns on first sits at the anchor, later ones appear to its right, and the rest shift back when an earlier one ends.

### Menu / playback controls
- **"Run Script"** is now disabled while a script is recording **or** playing (prevents launching a second script over a running one).
- New **"Stop Script"** item in the app menu, tray, and right-click context menu — enabled only while a script is playing.
- Menu/tray "Run Script" clicks now route through main's `run-script` handler so playback state is tracked centrally (previously they sent `play-script` straight to the display window, bypassing state tracking).
- `run-script` notifies the settings window via a new `script-playback-started` event, so the **Automation tab flips its ▶ to ■ Stop** even when the script was launched from a menu.

## Files
- `public/display.html` — flex indicator bar + blue/green indicator elements and the `playback-pulse` animation
- `public/render.js` — shared `toggleIndicator` helper with activation-order reflow; red dot refactored to use it
- `public/menu.js` — `stopScript` menu item, reroute "Run Script" through main, `isPlaying` threading in `updateScriptRecordingMenuItems`
- `public/main.js` — track/broadcast playback state; uniform menu-update calls
- `src/components/AutomationSection.js` — listen for `script-playback-started`

## Testing
- `npm run build` succeeds; `node --check` clean on all touched JS.
- Manually verified: launching a script from the tray/menu greys out "Run Script", enables "Stop Script", and flips the tab button to Stop; stopping from the menu ends playback and reverts state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)