### PR TITLE
Add MCP server for AI-driven device control and test automation (#88)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -65,6 +65,7 @@ React 17 app using React Bootstrap tabs. `App.js` is the root; each tab is a com
 | Overlay | `OverlaySection` | Load reference image for UI comparison |
 | Files | `FilesSection` | Default save paths for screenshots/recordings |
 | Automation | `AutomationSection` | Script recording, playback management, and step editing |
+| MCP | `MCPSection` | Enable/configure the embedded MCP server (port, auth token) + usage instructions |
 | About | `AboutSection` | Version, links |
 
 The React app communicates with the main process via `window.electronAPI` (exposed by `preload.js` via `contextBridge`).
@@ -79,6 +80,8 @@ The React app communicates with the main process via `window.electronAPI` (expos
 | `appletv.js` | Wraps `atvremote` CLI (pyatv) for Apple TV key sending and text input via `child_process.spawn` |
 | `menu.js` | macOS menu bar, system tray (Win/macOS), right-click context menu; includes Control Device quick-switch submenu and Automation scripts submenu |
 | `updater.js` | Polls GitHub Releases API; shows dialog if newer version found |
+| `mcp-server.js` | Embedded MCP server (localhost `127.0.0.1` only). Exposes `startMcpServer(ctx)`/`stopMcpServer()`; serves Streamable HTTP at `/mcp` and legacy SSE at `/sse` via Node's built-in `http`. Optional Bearer-token auth. The `@modelcontextprotocol/sdk` ships a CJS build, so it is `require`d directly. |
+| `mcp-tools.js` | MCP tool/resource/prompt registration (`registerAll(server, ctx)`) — thin wrappers over `ctx`. Holds the semantic→native key map used by `send_key`. |
 
 ### IPC Message Types (`shared-window-channel`)
 
@@ -98,6 +101,11 @@ Separate `ipcMain.on`/`ipcMain.handle` channels (outside `shared-window-channel`
 - Script management: `get-scripts`, `update-script-name`, `update-script-steps`, `delete-script`
 - File dialogs: `save-screenshot-dialog`, `save-video-dialog`, `select-adb-path`, `select-atv-path`, `load-image`, `load-image-by-path`
 - Settings persistence: `save-shortcut`, `save-launch-app-at-login`, `save-always-on-top`, `save-dark-mode`, etc.
+- MCP server: `save-mcp-config` / `get-mcp-status` (start/stop the server live, persist `settings.mcp`), `save-video-direct` (non-dialog recording save used by MCP). The main↔display renderer RPC for MCP uses `mcp-rpc-request` (main → display: `{requestId, action, params}`) and `mcp-rpc-response` (display → main: `{requestId, result|error}`); `action` is one of `capture-screenshot`, `send-key`, `send-text`, `start-recording`, `stop-recording`.
+
+### MCP Server
+
+`settings.mcp = { enabled, port, token }`. When enabled (toggle in the MCP tab → `MCPSection.js`), `main.js` starts `mcp-server.js` after the windows are created and stops it on `before-quit`. Tool handlers never import main directly — they call a `ctx` object built in `main.js` that reuses the existing internals (`switchControlDevice`, `startScriptPlayback`, ADB/ATV send fns, `settings`, menu refreshers) and the `callDisplay()` RPC helper for renderer-side work (canvas screenshot, `MediaRecorder`, key/text sending). `run_script` blocks by storing a resolver keyed by script id and settling it in the existing `script-playback-done` handler. See `docs/mcp-server.md` for the full tool/resource/prompt reference and agent usage.
 
 ### Device Control Protocols
 

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ yarn-debug.log*
 yarn-error.log*
 Untiltled
 out/
+.mcp.json

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "carabiner": {
+      "type": "http",
+      "url": "http://localhost:7734/mcp"
+    }
+  }
+}

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,8 +1,0 @@
-{
-  "mcpServers": {
-    "carabiner": {
-      "type": "http",
-      "url": "http://localhost:7734/mcp"
-    }
-  }
-}

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ For detailed setup and usage instructions, see our comprehensive guides:
 - **📸 [Screenshots](./docs/screenshots.md)** - Visual showcase of the application interface
 - **🤖 [Android / Fire TV Setup](./docs/setup-android-firetv.md)** - ADB setup for Fire TV and Google TV
 - **🍎 [Apple TV Setup](./docs/setup-apple-tv.md)** - pyatv setup and pairing for Apple TV
+- **🧠 [MCP Server](./docs/mcp-server.md)** - AI-driven device control and test automation via the Model Context Protocol
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Perfect for developers and QA engineers who need to test streaming applications 
 - **Text Pasting**: Paste clipboard content directly to streaming devices
 - **Screenshot Capture**: Save or copy screenshots with one click
 - **Automation Scripts**: Record key sequences with precise timing and replay them on demand
+- **MCP Server**: Let AI assistants control devices, run scripts, and capture screenshots via the Model Context Protocol for AI-driven QA automation
 - **Control Demo Mode**: Show the pressed control keys on the screen for demos and presentations
 
 ### Additional Features

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -1,0 +1,225 @@
+# MCP Server
+
+Carabiner can expose its device-control, automation, and capture features to AI assistants through
+an embedded [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server. This turns
+Carabiner into an **AI-native QA tool**: an agent (Claude Code, Claude Desktop, Cursor, etc.) can
+navigate a Roku / Fire TV / Apple TV app, capture screenshots, run automation scripts, and validate
+UI state without a human in the loop.
+
+The server runs inside Carabiner's main process and **binds only to `127.0.0.1`** — it is never
+exposed to the network.
+
+## Enabling the server
+
+1. Open **Settings → MCP**.
+2. Toggle **Enable**.
+3. Optionally change the **Port** (default `7734`) and set an **Auth Token**.
+   - The port and token are only editable while the server is stopped.
+4. The status line shows `Running — connect MCP clients to http://localhost:7734/mcp` when active.
+
+The server starts and stops live with the toggle (no app restart needed) and its enabled state is
+persisted in `settings.json`, so it comes back automatically on the next launch.
+
+## Transports
+
+Two transports are served simultaneously:
+
+| Endpoint | Transport | Use with |
+|----------|-----------|----------|
+| `http://localhost:<port>/mcp` | Streamable HTTP (recommended) | Claude Code, modern MCP clients |
+| `http://localhost:<port>/sse` | HTTP + SSE (legacy) | Older Claude Desktop / Cursor builds |
+
+## Authentication
+
+By default (empty token) the server accepts any local connection. If you set an **Auth Token**,
+every request must include it as a Bearer header:
+
+```
+Authorization: Bearer <your-token>
+```
+
+Requests without the matching header receive `401 Unauthorized`.
+
+## Connecting from Claude Code
+
+Add an `.mcp.json` file to your project (or use `claude mcp add`):
+
+```json
+{
+  "mcpServers": {
+    "carabiner": {
+      "type": "http",
+      "url": "http://localhost:7734/mcp"
+    }
+  }
+}
+```
+
+If you configured an auth token, add a header:
+
+```json
+{
+  "mcpServers": {
+    "carabiner": {
+      "type": "http",
+      "url": "http://localhost:7734/mcp",
+      "headers": { "Authorization": "Bearer your-token" }
+    }
+  }
+}
+```
+
+For a client that only supports SSE, use `"url": "http://localhost:7734/sse"` and drop the `type`
+field.
+
+## Tool reference
+
+### Device control
+| Tool | Description |
+|------|-------------|
+| `list_devices` | All configured control devices with protocol and connection status |
+| `select_device` | Switch the active device by id (`<ip>\|ecp`, `<ip>\|adb`, `<uuid-or-mac>\|atv`) |
+| `send_key` | Send one keypress (see [Keys](#keys)) |
+| `send_text` | Type a string on the current device |
+| `get_current_device` | Protocol, address, and connection state of the active device |
+
+### Capture & recording
+| Tool | Description |
+|------|-------------|
+| `list_capture_devices` | Available HDMI capture cards |
+| `select_capture_device` | Switch the active capture source |
+| `take_screenshot` | Capture the current frame; returns a PNG image and (by default) saves it to the screenshots folder |
+| `start_recording` | Begin recording (optional `filename_prefix`) |
+| `stop_recording` | Stop recording, save to the recordings folder, return the file path |
+
+### Automation scripts
+| Tool | Description |
+|------|-------------|
+| `list_scripts` | All saved scripts (id, name, controlType, step count) |
+| `run_script` | Run a script by id; **blocks until it completes or is cancelled** |
+| `stop_script` | Cancel the running script |
+| `create_script` | Create a script from a steps array |
+| `delete_script` | Remove a script by id |
+
+### Display & app state
+| Tool | Description |
+|------|-------------|
+| `show_display` / `hide_display` | Show or hide the floating display window |
+| `toggle_fullscreen` | Toggle fullscreen |
+| `toggle_on_top` | Toggle always-on-top |
+| `get_settings` | Read-only settings snapshot (auth token redacted) |
+| `get_app_info` | App version, OS, and MCP server status |
+
+### Resources
+| URI | Description |
+|-----|-------------|
+| `carabiner://devices` | Device list + selected device |
+| `carabiner://scripts` | All saved scripts |
+| `carabiner://settings` | Settings snapshot (token redacted) |
+| `carabiner://screenshot/latest` | Current frame as a PNG |
+
+### Prompts
+| Prompt | Description |
+|--------|-------------|
+| `qa_navigation_test` | Guided home → content → playback → back navigation test with screenshots |
+| `record_script_from_description` | Turn a natural-language workflow into a `create_script` steps array |
+
+### Keys
+
+`send_key` accepts friendly, protocol-agnostic names that are translated to each device's native
+key: `up`, `down`, `left`, `right`, `select`/`ok`, `back`, `home`, `play`/`pause`, `rewind`,
+`forward`, `replay`, `info`, `volume_up`, `volume_down`, `volume_mute`. You may also pass a raw
+protocol-native key (a Roku ECP command such as `search`, an ADB keycode, or an Apple TV command)
+and it will be forwarded as-is. Keys not available on the active protocol return an error.
+
+## Driving QA test cases with an AI agent
+
+Once connected, describe the test in natural language and let the agent orchestrate the tools. For
+example, from Claude Code:
+
+```
+Using the carabiner MCP server: select my Roku device, go home, open Search,
+type "stranger things", take a screenshot, and tell me whether results appeared.
+```
+
+The agent will chain calls such as:
+
+```
+select_device("192.168.1.50|ecp")
+send_key("home")
+send_key("search")        # or the raw ECP command if your app uses a custom search entry
+send_text("stranger things")
+take_screenshot()         # image returned to the agent for visual inspection
+```
+
+A repeatable regression can be captured once and replayed deterministically:
+
+```
+create_script({ controlType: "ecp", steps: [
+  { key: "home",   mod: -1, delay: 0 },
+  { key: "down",   mod: -1, delay: 800 },
+  { key: "select", mod: -1, delay: 1500 },
+  { key: "play",   mod: -1, delay: 2000 }
+]})
+run_script("<id>")        # blocks until done
+take_screenshot()
+```
+
+> Step `mod` values follow Carabiner's automation format: `-1` = full keypress (ECP), `0` = press
+> for ADB/ATV, `100` = key-up. `delay` is milliseconds to wait *before* the step.
+
+## Scheduling test runs externally
+
+Carabiner has no built-in scheduler — scheduling is handled **outside** the app by an AI agent so
+you can use the full power of natural-language test definitions. The recommended pattern is Claude
+Code in non-interactive mode (`claude -p`) triggered by your OS scheduler.
+
+### 1. Write the test as a prompt
+
+Save a reusable instruction file, e.g. `nightly-regression.md`:
+
+```
+Connect to the carabiner MCP server.
+1. select_device for the Roku under test and start_recording with filename_prefix "nightly".
+2. run_script "<smoke-test-id>".
+3. take_screenshot after the script completes.
+4. stop_recording and report the saved video path.
+5. Summarize PASS/FAIL with anything unexpected you saw in the screenshots.
+```
+
+### 2. Schedule it
+
+**macOS / Linux (cron)** — run every night at 02:00:
+
+```cron
+0 2 * * * cd /path/to/project && claude -p "$(cat nightly-regression.md)" >> ~/carabiner-nightly.log 2>&1
+```
+
+**macOS (launchd)** or **Windows (Task Scheduler)** work the same way — point the scheduled action at
+`claude -p` with the prompt file. On Windows:
+
+```bat
+claude -p "%CD%\nightly-regression.md content here" >> carabiner-nightly.log 2>&1
+```
+
+> Make sure Carabiner is running with the MCP server enabled (and the capture device streaming) at
+> the scheduled time — e.g. enable **Launch at Login** in Settings → General.
+
+### 3. Or loop within Claude Code
+
+For ad-hoc repeated runs during a test session, use Claude Code's `/loop`:
+
+```
+/loop 30m run nightly-regression.md against the carabiner MCP server
+```
+
+This re-runs the same QA task every 30 minutes without any external scheduler.
+
+## Troubleshooting
+
+- **`take_screenshot` / recording errors with "No active video stream"** — select a capture device
+  first (the display window must be streaming). Use `select_capture_device` or pick one in the
+  General tab.
+- **`send_key` returns "No control device selected"** — call `select_device` first.
+- **Port already in use** — change the port in the MCP Server card and reconnect your client.
+- **401 Unauthorized** — your client is missing the `Authorization: Bearer <token>` header.

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -129,6 +129,14 @@ The **Automation** tab lets you record key sequences (with the exact timing betw
 
 > **Note:** Scripts are tied to the protocol of the device that was active when they were recorded (ECP for Roku, ADB for Android). Playing a script on a device with a different protocol will show a warning toast, but playback will still proceed.
 
+### AI Automation (MCP Server)
+
+Carabiner can expose its device control, automation, and capture features to AI assistants through
+an embedded **MCP server** (enable it in the **Settings → MCP** tab). An agent such as
+Claude Code can then navigate your app, run scripts, capture screenshots, and validate UI state —
+and you can schedule recurring QA runs externally. See the **[MCP Server guide](./mcp-server.md)**
+for setup and examples.
+
 ### Overlay Images
 
 Load reference images for design comparison:

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "@testing-library/jest-dom": "^5.16.2",
         "@testing-library/react": "^12.1.4",
         "@testing-library/user-event": "^13.5.0",
@@ -21,7 +22,8 @@
         "react-dom": "^17.0.2",
         "react-scripts": "5.0.0",
         "toastify-js": "^1.12.0",
-        "web-vitals": "^2.1.4"
+        "web-vitals": "^2.1.4",
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@electron-forge/cli": "^7.11.2",
@@ -3263,6 +3265,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.13.0",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
@@ -4708,6 +4722,421 @@
       },
       "engines": {
         "node": ">= 12.13.0"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
@@ -8987,6 +9416,23 @@
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "license": "MIT"
     },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/cosmiconfig": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
@@ -11737,6 +12183,27 @@
         "node": ">=0.8.x"
       }
     },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/execa": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
@@ -11912,6 +12379,24 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
       }
     },
     "node_modules/express/node_modules/debug": {
@@ -13180,6 +13665,15 @@
         "he": "bin/he"
       }
     },
+    "node_modules/hono": {
+      "version": "4.12.25",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
+      "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
     "node_modules/hoopy": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/hoopy/-/hoopy-0.1.4.tgz",
@@ -13738,7 +14232,6 @@
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
       "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -14135,6 +14628,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "license": "MIT"
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "license": "MIT"
     },
     "node_modules/is-property": {
@@ -17055,6 +17554,15 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -17181,6 +17689,12 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -19212,6 +19726,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/pkg-dir": {
@@ -21967,6 +22490,32 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "randombytes": "^2.1.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/router/node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/run-parallel": {
@@ -25829,6 +26378,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "repo": "carabiner"
   },
   "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@testing-library/jest-dom": "^5.16.2",
     "@testing-library/react": "^12.1.4",
     "@testing-library/user-event": "^13.5.0",
@@ -36,7 +37,8 @@
     "react-dom": "^17.0.2",
     "react-scripts": "5.0.0",
     "toastify-js": "^1.12.0",
-    "web-vitals": "^2.1.4"
+    "web-vitals": "^2.1.4",
+    "zod": "^4.4.3"
   },
   "homepage": "./",
   "scripts": {

--- a/public/main.js
+++ b/public/main.js
@@ -47,6 +47,7 @@ const {
   hideWindowSafely,
 } = require("./menu");
 const { checkForUpdates } = require("./updater");
+const { startMcpServer, stopMcpServer, isRunning: isMcpRunning, getPort: getMcpPort } = require("./mcp-server");
 const packageInfo = JSON.parse(fs.readFileSync(path.join(__dirname, "../package.json"), "utf8"));
 
 if (require("electron-squirrel-startup") === true) app.quit();
@@ -1116,6 +1117,264 @@ app.whenReady().then(async () => {
     mainWindow?.webContents.send("script-recording-state-changed", recording);
   });
 
+  // ----------------------------- MCP server integration -----------------------------
+  // Request/response RPC to the display window (renderer) for operations that must run there
+  // (canvas screenshot, MediaRecorder, key/text sending). Reuses render.js internals.
+  const mcpPendingRpc = new Map();
+  let mcpRpcSeq = 0;
+  function callDisplay(action, params = {}) {
+    return new Promise((resolve, reject) => {
+      if (!displayWindow || displayWindow.isDestroyed()) {
+        reject(new Error("Display window is not available."));
+        return;
+      }
+      const requestId = `rpc_${++mcpRpcSeq}`;
+      const timeout = setTimeout(() => {
+        if (mcpPendingRpc.has(requestId)) {
+          mcpPendingRpc.delete(requestId);
+          reject(new Error(`Display did not respond to "${action}" in time.`));
+        }
+      }, 20000);
+      mcpPendingRpc.set(requestId, { resolve, reject, timeout });
+      displayWindow.webContents.send("mcp-rpc-request", { requestId, action, params });
+    });
+  }
+  ipcMain.on("mcp-rpc-response", (event, { requestId, result, error }) => {
+    const pending = mcpPendingRpc.get(requestId);
+    if (!pending) return;
+    clearTimeout(pending.timeout);
+    mcpPendingRpc.delete(requestId);
+    if (error) pending.reject(new Error(error));
+    else pending.resolve(result);
+  });
+
+  // Shared script playback used by both the run-script IPC and the MCP run_script tool.
+  const mcpPendingScripts = new Map();
+  function startScriptPlayback(scriptId) {
+    if (isScriptRecording || isScriptPlaying) return false;
+    const script = settings.scripts?.find((s) => s.id === scriptId);
+    if (!script) return false;
+    if (displayWindow && !displayWindow.isVisible()) displayWindow.show();
+    isScriptPlaying = true;
+    updateScriptRecordingMenuItems(isScriptRecording || isScriptPlaying, isScriptRecording, isScriptPlaying);
+    mainWindow?.webContents.send("script-playback-started", script.id);
+    displayWindow?.webContents.send("play-script", {
+      id: script.id,
+      steps: script.steps,
+      controlType: script.controlType,
+    });
+    return true;
+  }
+
+  function mcpTimestamp() {
+    const now = new Date();
+    const datePart = now.toLocaleDateString("en-CA");
+    const timePart = now.toLocaleTimeString("en-CA", { hour12: false }).replace(/:/g, "");
+    return `${datePart}-${timePart}`;
+  }
+
+  // Non-interactive video save (no dialog) used when recording is driven via MCP.
+  ipcMain.handle("save-video-direct", async (event, filename, bufferData) => {
+    try {
+      const dir = settings.files?.recordingPath || path.join(os.homedir(), isMacOS ? "Movies" : "Videos");
+      const filePath = path.join(dir, filename);
+      await fs.promises.writeFile(filePath, Buffer.from(bufferData));
+      return { success: true, filePath };
+    } catch (error) {
+      return { success: false, error: error.message };
+    }
+  });
+
+  // Context object handed to the MCP tool handlers — the only bridge into main state.
+  const mcpCtx = {
+    getSettings: () => settings,
+    getAuthToken: () => settings.mcp?.token || "",
+    getSettingsSnapshot: () => {
+      const snap = JSON.parse(JSON.stringify(settings));
+      if (snap.mcp && snap.mcp.token) snap.mcp.token = "***";
+      return snap;
+    },
+    getAppInfo: () => ({
+      name: packageInfo.name,
+      version: packageInfo.version,
+      platform: process.platform,
+      arch: process.arch,
+      electron: process.versions.electron,
+      mcp: { running: isMcpRunning(), port: getMcpPort() },
+    }),
+    // Device control
+    getCurrentDevice: () => {
+      const id = settings.control.deviceId || "";
+      const [ip = "", type = ""] = id ? id.split("|") : [];
+      let connected = false;
+      if (type === "adb") connected = isADBConnected;
+      else if (type === "atv") connected = isATVConnected;
+      else if (type === "ecp") connected = !!ip;
+      return { id, ip, type, connected };
+    },
+    listDevices: () =>
+      (settings.control.deviceList || []).map((d) => ({
+        id: d.id,
+        name: d.alias || "",
+        deviceType: d.type || "",
+        ipAddress: d.ipAddress || (d.id ? d.id.split("|")[0] : ""),
+        protocol: d.id ? d.id.split("|")[1] : "",
+        selected: d.id === settings.control.deviceId,
+      })),
+    selectDevice: (deviceId) => {
+      const device = (settings.control.deviceList || []).find((d) => d.id === deviceId);
+      if (!device) throw new Error(`Unknown device id: ${deviceId}`);
+      const newIp = deviceId.split("|")[0];
+      // switchControlDevice handles ADB but not ATV; reconcile ATV connection here.
+      if (isATVConnected && controlIp !== newIp) isATVConnected = disconnectATV();
+      switchControlDevice(deviceId);
+      if (controlType === "atv" && !isATVConnected) {
+        isATVConnected = connectATV(controlIp, settings.control?.atvremotePath);
+      }
+      return mcpCtx.getCurrentDevice();
+    },
+    sendKey: async (nativeKey, mod) => {
+      if (!settings.control.deviceId) {
+        throw new Error("No control device selected. Use select_device first.");
+      }
+      await callDisplay("send-key", { key: nativeKey, mod });
+      return { sent: nativeKey };
+    },
+    sendText: async (text) => {
+      if (!settings.control.deviceId) {
+        throw new Error("No control device selected. Use select_device first.");
+      }
+      await callDisplay("send-text", { text });
+      return { sent: text };
+    },
+    // Capture & recording
+    listCaptureDevices: () =>
+      (captureDevices || []).map((d) => ({ deviceId: d.deviceId, label: d.label })),
+    selectCaptureDevice: (deviceId) => {
+      const found = (captureDevices || []).find((d) => d.deviceId === deviceId);
+      if (!found) throw new Error(`Unknown capture device id: ${deviceId}`);
+      mainWindow?.webContents?.send("update-capture-device", deviceId);
+      return { deviceId: found.deviceId, label: found.label };
+    },
+    takeScreenshot: async ({ save = true } = {}) => {
+      const dataUrl = await callDisplay("capture-screenshot");
+      if (!dataUrl || typeof dataUrl !== "string") {
+        throw new Error("No video frame available to capture.");
+      }
+      const base64 = dataUrl.replace(/^data:image\/[a-z]+;base64,/, "");
+      let filePath = null;
+      if (save) {
+        const dir = settings.files?.screenshotPath || path.join(os.homedir(), "Pictures");
+        filePath = path.join(dir, `carabiner-${mcpTimestamp()}.png`);
+        await fs.promises.writeFile(filePath, Buffer.from(base64, "base64"));
+      }
+      return { base64, mimeType: "image/png", filePath };
+    },
+    startRecording: async ({ filenamePrefix } = {}) => {
+      await callDisplay("start-recording", { filenamePrefix });
+      return { recording: true };
+    },
+    stopRecording: async () => callDisplay("stop-recording"),
+    // Scripts
+    listScripts: () =>
+      (settings.scripts || []).map((s) => ({
+        id: s.id,
+        name: s.name,
+        controlType: s.controlType,
+        stepCount: s.steps?.length || 0,
+      })),
+    getScripts: () => settings.scripts || [],
+    runScript: (scriptId) =>
+      new Promise((resolve, reject) => {
+        if (isScriptRecording || isScriptPlaying) {
+          reject(new Error("Busy: a script is already recording or playing."));
+          return;
+        }
+        const script = settings.scripts?.find((s) => s.id === scriptId);
+        if (!script) {
+          reject(new Error(`Unknown script id: ${scriptId}`));
+          return;
+        }
+        mcpPendingScripts.set(scriptId, resolve);
+        if (!startScriptPlayback(scriptId)) {
+          mcpPendingScripts.delete(scriptId);
+          reject(new Error("Failed to start script playback."));
+        }
+      }),
+    stopScript: () => {
+      displayWindow?.webContents.send("stop-script");
+      return { stopped: true };
+    },
+    createScript: ({ name, controlType, steps }) => {
+      if (!settings.scripts) settings.scripts = [];
+      const id = Date.now().toString(36) + Math.random().toString(36).slice(2);
+      const script = {
+        id,
+        name: (name && name.trim()) || `Script ${settings.scripts.length + 1}`,
+        controlType,
+        steps: (steps || []).map((s) => ({ key: s.key, mod: s.mod ?? 0, delay: s.delay ?? 0 })),
+      };
+      settings.scripts.push(script);
+      saveSettings(settings);
+      mainWindow?.webContents.send("shared-window-channel", { type: "scripts-updated", payload: settings.scripts });
+      updateScriptsSubmenu(settings.scripts, mainWindow, displayWindow, packageInfo, settings);
+      return { id: script.id, name: script.name, controlType: script.controlType, stepCount: script.steps.length };
+    },
+    deleteScript: (scriptId) => {
+      const before = settings.scripts?.length || 0;
+      settings.scripts = (settings.scripts || []).filter((s) => s.id !== scriptId);
+      saveSettings(settings);
+      mainWindow?.webContents.send("shared-window-channel", { type: "scripts-updated", payload: settings.scripts });
+      updateScriptsSubmenu(settings.scripts, mainWindow, displayWindow, packageInfo, settings);
+      return { deleted: before !== settings.scripts.length };
+    },
+    // Display window
+    showDisplay: () => {
+      if (!displayWindow.isVisible()) displayWindow.show();
+      return { visible: true };
+    },
+    hideDisplay: () => {
+      if (displayWindow.isVisible()) displayWindow.hide();
+      return { visible: false };
+    },
+    toggleFullscreen: () => {
+      toggleFullScreen(displayWindow);
+      return { fullscreen: displayWindow.isFullScreen() };
+    },
+    toggleOnTop: () => {
+      const newVal = !(settings.display.alwaysOnTop ?? true);
+      settings.display.alwaysOnTop = newVal;
+      saveSettings(settings);
+      if (!displayWindow.isVisible()) displayWindow.show();
+      setAlwaysOnTop(newVal, displayWindow);
+      updateAlwaysOnTopMenuItem(newVal);
+      mainWindow?.webContents?.send("update-always-on-top", newVal);
+      return { onTop: newVal };
+    },
+  };
+
+  ipcMain.handle("save-mcp-config", async (event, config) => {
+    settings.mcp = {
+      enabled: !!config.enabled,
+      port: Number(config.port) || 7734,
+      token: typeof config.token === "string" ? config.token : "",
+    };
+    saveSettings(settings);
+    await stopMcpServer();
+    if (settings.mcp.enabled) {
+      return startMcpServer(mcpCtx);
+    }
+    return { running: false, port: settings.mcp.port };
+  });
+
+  ipcMain.handle("get-mcp-status", async () => ({ running: isMcpRunning(), port: getMcpPort() }));
+
+  if (settings.mcp?.enabled) {
+    startMcpServer(mcpCtx).then((status) => {
+      if (status.error) log.error("[MCP] Failed to start MCP server:", status.error);
+    });
+  }
+
   ipcMain.on("save-script", (event, script) => {
     if (!settings.scripts) settings.scripts = [];
     script.name = `Script ${settings.scripts.length + 1}`;
@@ -1136,20 +1395,7 @@ app.whenReady().then(async () => {
   });
 
   ipcMain.on("run-script", (event, scriptId) => {
-    if (isScriptRecording || isScriptPlaying) return;
-    const script = settings.scripts?.find((s) => s.id === scriptId);
-    if (script) {
-      if (displayWindow && !displayWindow.isVisible()) displayWindow.show();
-      isScriptPlaying = true;
-      updateScriptRecordingMenuItems(isScriptRecording || isScriptPlaying, isScriptRecording, isScriptPlaying);
-      // Notify the settings window so the Automation tab reflects the running script
-      mainWindow?.webContents.send("script-playback-started", script.id);
-      displayWindow?.webContents.send("play-script", {
-        id: script.id,
-        steps: script.steps,
-        controlType: script.controlType,
-      });
-    }
+    startScriptPlayback(scriptId);
   });
 
   ipcMain.on("stop-script", () => {
@@ -1160,6 +1406,12 @@ app.whenReady().then(async () => {
     isScriptPlaying = false;
     updateScriptRecordingMenuItems(isScriptRecording || isScriptPlaying, isScriptRecording, isScriptPlaying);
     mainWindow?.webContents.send("script-playback-done", scriptId);
+    // Resolve any pending MCP run_script promise waiting on this script.
+    const pending = mcpPendingScripts.get(scriptId);
+    if (pending) {
+      mcpPendingScripts.delete(scriptId);
+      pending({ id: scriptId, completed: true });
+    }
   });
 
   app.on("activate", () => {
@@ -1169,6 +1421,9 @@ app.whenReady().then(async () => {
   });
   app.on("before-quit", () => {
     isQuitting = true;
+    if (isMcpRunning()) {
+      stopMcpServer();
+    }
     if (isADBConnected) {
       disconnectADB();
     }

--- a/public/mcp-server.js
+++ b/public/mcp-server.js
@@ -1,0 +1,249 @@
+/*---------------------------------------------------------------------------------------------
+ *  Carabiner - Simple Screen Capture and Remote Control App for Streaming Devices
+ *
+ *  Repository: https://github.com/lvcabral/carabiner
+ *
+ *  Copyright (c) 2024-2026 Marcelo Lv Cabral. All Rights Reserved.
+ *
+ *  Licensed under the MIT License. See LICENSE in the repository root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Embedded MCP (Model Context Protocol) server for Carabiner.
+ *
+ * Runs inside the Electron main process and exposes Carabiner's device control, automation and
+ * capture features to AI assistants. Binds only to 127.0.0.1 and supports two transports:
+ *   - Streamable HTTP at POST/GET/DELETE /mcp   (recommended, modern clients)
+ *   - HTTP+SSE at GET /sse + POST /messages     (legacy compatibility)
+ *
+ * The MCP SDK ships a CommonJS build, so it is required directly (no dynamic import needed).
+ */
+const http = require("http");
+const { randomUUID } = require("crypto");
+const log = require("electron-log");
+
+const { McpServer } = require("@modelcontextprotocol/sdk/server/mcp.js");
+const {
+  StreamableHTTPServerTransport,
+} = require("@modelcontextprotocol/sdk/server/streamableHttp.js");
+const { SSEServerTransport } = require("@modelcontextprotocol/sdk/server/sse.js");
+const { isInitializeRequest } = require("@modelcontextprotocol/sdk/types.js");
+
+const { registerAll } = require("./mcp-tools");
+
+const HOST = "127.0.0.1";
+const SERVER_INFO = { name: "carabiner", version: "1.0.0" };
+
+let httpServer = null;
+let currentPort = null;
+let activeCtx = null;
+// Streamable HTTP transports keyed by mcp session id.
+const streamableTransports = new Map();
+// SSE transports keyed by session id.
+const sseTransports = new Map();
+
+function isRunning() {
+  return httpServer !== null;
+}
+
+function getPort() {
+  return currentPort;
+}
+
+function buildServer() {
+  const server = new McpServer(SERVER_INFO);
+  registerAll(server, activeCtx);
+  return server;
+}
+
+function readJsonBody(req) {
+  return new Promise((resolve) => {
+    let data = "";
+    req.on("data", (chunk) => {
+      data += chunk;
+    });
+    req.on("end", () => {
+      if (!data) {
+        resolve(undefined);
+        return;
+      }
+      try {
+        resolve(JSON.parse(data));
+      } catch {
+        resolve(undefined);
+      }
+    });
+    req.on("error", () => resolve(undefined));
+  });
+}
+
+function sendJson(res, statusCode, payload) {
+  res.writeHead(statusCode, { "Content-Type": "application/json" });
+  res.end(JSON.stringify(payload));
+}
+
+function isAuthorized(req) {
+  const token = activeCtx.getAuthToken();
+  if (!token) return true; // No token configured: auth disabled.
+  const header = req.headers["authorization"] || "";
+  return header === `Bearer ${token}`;
+}
+
+async function handleStreamablePost(req, res, body) {
+  const sessionId = req.headers["mcp-session-id"];
+  let transport = sessionId ? streamableTransports.get(sessionId) : undefined;
+
+  if (!transport) {
+    if (sessionId || !isInitializeRequest(body)) {
+      sendJson(res, 400, {
+        jsonrpc: "2.0",
+        error: { code: -32000, message: "Bad Request: no valid session for this request." },
+        id: null,
+      });
+      return;
+    }
+    // New initialization request: create a session-managed transport.
+    transport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: () => randomUUID(),
+      onsessioninitialized: (id) => streamableTransports.set(id, transport),
+    });
+    transport.onclose = () => {
+      if (transport.sessionId) streamableTransports.delete(transport.sessionId);
+    };
+    const server = buildServer();
+    await server.connect(transport);
+  }
+
+  await transport.handleRequest(req, res, body);
+}
+
+async function handleStreamableSession(req, res) {
+  const sessionId = req.headers["mcp-session-id"];
+  const transport = sessionId ? streamableTransports.get(sessionId) : undefined;
+  if (!transport) {
+    sendJson(res, 400, {
+      jsonrpc: "2.0",
+      error: { code: -32000, message: "Bad Request: unknown or missing session id." },
+      id: null,
+    });
+    return;
+  }
+  await transport.handleRequest(req, res);
+}
+
+async function handleSseConnect(req, res) {
+  const transport = new SSEServerTransport("/messages", res);
+  sseTransports.set(transport.sessionId, transport);
+  res.on("close", () => sseTransports.delete(transport.sessionId));
+  const server = buildServer();
+  await server.connect(transport);
+}
+
+async function handleSseMessage(req, res, url) {
+  const sessionId = url.searchParams.get("sessionId");
+  const transport = sessionId ? sseTransports.get(sessionId) : undefined;
+  if (!transport) {
+    sendJson(res, 400, { error: "No active SSE session for the provided sessionId." });
+    return;
+  }
+  await transport.handlePostMessage(req, res);
+}
+
+async function onRequest(req, res) {
+  try {
+    if (!isAuthorized(req)) {
+      sendJson(res, 401, { error: "Unauthorized" });
+      return;
+    }
+
+    const url = new URL(req.url, `http://${HOST}`);
+    const pathname = url.pathname;
+
+    if (pathname === "/mcp") {
+      if (req.method === "POST") {
+        const body = await readJsonBody(req);
+        await handleStreamablePost(req, res, body);
+      } else if (req.method === "GET" || req.method === "DELETE") {
+        await handleStreamableSession(req, res);
+      } else {
+        sendJson(res, 405, { error: "Method Not Allowed" });
+      }
+      return;
+    }
+
+    if (pathname === "/sse" && req.method === "GET") {
+      await handleSseConnect(req, res);
+      return;
+    }
+
+    if (pathname === "/messages" && req.method === "POST") {
+      await handleSseMessage(req, res, url);
+      return;
+    }
+
+    sendJson(res, 404, { error: "Not Found" });
+  } catch (error) {
+    log.error("[MCP] Request error:", error);
+    if (!res.headersSent) {
+      sendJson(res, 500, { error: "Internal Server Error" });
+    }
+  }
+}
+
+/**
+ * Start the MCP server. `ctx` provides all the internal accessors the tool handlers need.
+ * Returns { running, port, error }.
+ */
+function startMcpServer(ctx) {
+  return new Promise((resolve) => {
+    if (isRunning()) {
+      resolve({ running: true, port: currentPort });
+      return;
+    }
+    activeCtx = ctx;
+    const port = ctx.getSettings().mcp?.port || 7734;
+
+    httpServer = http.createServer(onRequest);
+    httpServer.on("error", (error) => {
+      log.error("[MCP] Server error:", error);
+      httpServer = null;
+      currentPort = null;
+      resolve({ running: false, port, error: error.message });
+    });
+    httpServer.listen(port, HOST, () => {
+      currentPort = port;
+      log.info(`[MCP] Server listening on http://${HOST}:${port} (/mcp and /sse)`);
+      resolve({ running: true, port });
+    });
+  });
+}
+
+/** Stop the MCP server and close all active transports. */
+async function stopMcpServer() {
+  for (const transport of streamableTransports.values()) {
+    try {
+      await transport.close();
+    } catch {
+      /* ignore */
+    }
+  }
+  streamableTransports.clear();
+  for (const transport of sseTransports.values()) {
+    try {
+      await transport.close();
+    } catch {
+      /* ignore */
+    }
+  }
+  sseTransports.clear();
+
+  if (httpServer) {
+    await new Promise((resolve) => httpServer.close(() => resolve()));
+    httpServer = null;
+  }
+  currentPort = null;
+  log.info("[MCP] Server stopped");
+  return { running: false };
+}
+
+module.exports = { startMcpServer, stopMcpServer, isRunning, getPort };

--- a/public/mcp-tools.js
+++ b/public/mcp-tools.js
@@ -1,0 +1,516 @@
+/*---------------------------------------------------------------------------------------------
+ *  Carabiner - Simple Screen Capture and Remote Control App for Streaming Devices
+ *
+ *  Repository: https://github.com/lvcabral/carabiner
+ *
+ *  Copyright (c) 2024-2026 Marcelo Lv Cabral. All Rights Reserved.
+ *
+ *  Licensed under the MIT License. See LICENSE in the repository root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * MCP tool / resource / prompt registration for Carabiner.
+ *
+ * Every handler is a thin wrapper over the `ctx` object provided by `main.js`, which in turn
+ * reuses the same internal functions already used by the IPC layer (device control, scripts,
+ * screenshots, recording). No device/control logic is duplicated here.
+ */
+const { z } = require("zod");
+
+/**
+ * Friendly, protocol-agnostic key names mapped to each protocol's native key.
+ * Mirrors the per-protocol maps in `render.js`. A `null` value means the key is not available
+ * for that protocol. Callers may also pass a raw protocol-native key (e.g. an ADB keycode or a
+ * Roku ECP command such as "search") which is forwarded as-is.
+ */
+const SEMANTIC_KEYS = {
+  up: { ecp: "up", adb: "19", atv: "up" },
+  down: { ecp: "down", adb: "20", atv: "down" },
+  left: { ecp: "left", adb: "21", atv: "left" },
+  right: { ecp: "right", adb: "22", atv: "right" },
+  select: { ecp: "select", adb: "66", atv: "select" },
+  ok: { ecp: "select", adb: "66", atv: "select" },
+  back: { ecp: "back", adb: "4", atv: "menu" },
+  home: { ecp: "home", adb: "3", atv: "home" },
+  play: { ecp: "play", adb: "85", atv: "play_pause" },
+  pause: { ecp: "play", adb: "85", atv: "play_pause" },
+  rewind: { ecp: "rev", adb: "89", atv: "previous" },
+  forward: { ecp: "fwd", adb: "90", atv: "next" },
+  replay: { ecp: "instantreplay", adb: null, atv: null },
+  info: { ecp: "info", adb: null, atv: "top_menu" },
+  options: { ecp: "info", adb: null, atv: "top_menu" },
+  volume_mute: { ecp: "volumemute", adb: "164", atv: null },
+  volume_up: { ecp: null, adb: "24", atv: "volume_up" },
+  volume_down: { ecp: null, adb: "25", atv: "volume_down" },
+};
+
+const SEMANTIC_KEY_NAMES = Object.keys(SEMANTIC_KEYS);
+
+// A single "press" maps to a different `mod` value per protocol (see render.js sendKey).
+function modForProtocol(type) {
+  return type === "ecp" ? -1 : 0;
+}
+
+/**
+ * Translate a requested key into the native key + mod for the active protocol.
+ * Returns { key, mod } or throws a descriptive Error.
+ */
+function resolveKey(requestedKey, type) {
+  if (!type) {
+    throw new Error("No control device selected. Use select_device first.");
+  }
+  const mod = modForProtocol(type);
+  const semantic = SEMANTIC_KEYS[requestedKey.toLowerCase()];
+  if (semantic) {
+    const native = semantic[type];
+    if (!native) {
+      throw new Error(`Key "${requestedKey}" is not supported on ${type.toUpperCase()} devices.`);
+    }
+    return { key: native, mod };
+  }
+  // Fall back to treating the input as a raw protocol-native key.
+  return { key: requestedKey, mod };
+}
+
+// ----------------------------- response helpers -----------------------------
+
+function textResult(value) {
+  const text = typeof value === "string" ? value : JSON.stringify(value, null, 2);
+  return { content: [{ type: "text", text }] };
+}
+
+function errorResult(error) {
+  const message = error instanceof Error ? error.message : String(error);
+  return { content: [{ type: "text", text: `Error: ${message}` }], isError: true };
+}
+
+// Wrap an async handler so thrown errors become MCP error results instead of transport failures.
+function handler(fn) {
+  return async (args, extra) => {
+    try {
+      return await fn(args, extra);
+    } catch (error) {
+      return errorResult(error);
+    }
+  };
+}
+
+// ----------------------------- registration -----------------------------
+
+function registerAll(server, ctx) {
+  registerDeviceTools(server, ctx);
+  registerCaptureTools(server, ctx);
+  registerScriptTools(server, ctx);
+  registerDisplayTools(server, ctx);
+  registerStateTools(server, ctx);
+  registerResources(server, ctx);
+  registerPrompts(server, ctx);
+}
+
+function registerDeviceTools(server, ctx) {
+  server.registerTool(
+    "list_devices",
+    {
+      title: "List control devices",
+      description:
+        "Return all configured control devices with their protocol (ecp/adb/atv) and connection status.",
+    },
+    handler(async () => textResult(ctx.listDevices()))
+  );
+
+  server.registerTool(
+    "select_device",
+    {
+      title: "Select control device",
+      description:
+        "Switch the active control device by its id (formats: '<ip>|ecp', '<ip>|adb', '<uuid-or-mac>|atv').",
+      inputSchema: {
+        deviceId: z.string().describe("Device id in '<address>|<protocol>' form."),
+      },
+    },
+    handler(async ({ deviceId }) => textResult(await ctx.selectDevice(deviceId)))
+  );
+
+  server.registerTool(
+    "get_current_device",
+    {
+      title: "Get current device",
+      description: "Return protocol, address, and connection state of the active control device.",
+    },
+    handler(async () => textResult(ctx.getCurrentDevice()))
+  );
+
+  server.registerTool(
+    "send_key",
+    {
+      title: "Send key",
+      description:
+        "Send a single keypress to the current device. Accepts a friendly name (" +
+        SEMANTIC_KEY_NAMES.join(", ") +
+        ") or a raw protocol-native key (ECP command, ADB keycode, or ATV command).",
+      inputSchema: {
+        key: z.string().describe("Friendly key name or raw protocol-native key."),
+      },
+    },
+    handler(async ({ key }) => {
+      const current = ctx.getCurrentDevice();
+      const { key: nativeKey, mod } = resolveKey(key, current.type);
+      await ctx.sendKey(nativeKey, mod);
+      return textResult({ sent: key, nativeKey, protocol: current.type });
+    })
+  );
+
+  server.registerTool(
+    "send_text",
+    {
+      title: "Send text",
+      description: "Type a text string on the current device.",
+      inputSchema: {
+        text: z.string().describe("Text to type."),
+      },
+    },
+    handler(async ({ text }) => {
+      await ctx.sendText(text);
+      return textResult({ sent: text });
+    })
+  );
+}
+
+function registerCaptureTools(server, ctx) {
+  server.registerTool(
+    "list_capture_devices",
+    {
+      title: "List capture devices",
+      description: "List available HDMI capture cards / video input devices.",
+    },
+    handler(async () => textResult(ctx.listCaptureDevices()))
+  );
+
+  server.registerTool(
+    "select_capture_device",
+    {
+      title: "Select capture device",
+      description: "Switch the active capture source by its deviceId.",
+      inputSchema: {
+        deviceId: z.string().describe("Capture device id (deviceId from list_capture_devices)."),
+      },
+    },
+    handler(async ({ deviceId }) => textResult(await ctx.selectCaptureDevice(deviceId)))
+  );
+
+  server.registerTool(
+    "take_screenshot",
+    {
+      title: "Take screenshot",
+      description:
+        "Capture the current frame. Returns the image to the caller and (unless save=false) also " +
+        "saves a PNG to the configured screenshots folder.",
+      inputSchema: {
+        save: z
+          .boolean()
+          .optional()
+          .describe("Whether to also save the PNG to disk (default true)."),
+      },
+    },
+    handler(async ({ save }) => {
+      const shot = await ctx.takeScreenshot({ save: save !== false });
+      return {
+        content: [
+          { type: "image", data: shot.base64, mimeType: shot.mimeType },
+          {
+            type: "text",
+            text: shot.filePath ? `Saved to ${shot.filePath}` : "Captured (not saved to disk).",
+          },
+        ],
+      };
+    })
+  );
+
+  server.registerTool(
+    "start_recording",
+    {
+      title: "Start recording",
+      description: "Begin video recording of the current capture stream.",
+      inputSchema: {
+        filename_prefix: z
+          .string()
+          .optional()
+          .describe("Optional filename prefix for the saved recording."),
+      },
+    },
+    handler(async ({ filename_prefix }) => {
+      await ctx.startRecording({ filenamePrefix: filename_prefix });
+      return textResult({ recording: true });
+    })
+  );
+
+  server.registerTool(
+    "stop_recording",
+    {
+      title: "Stop recording",
+      description: "Stop recording, save the file, and return the saved file path.",
+    },
+    handler(async () => textResult(await ctx.stopRecording()))
+  );
+}
+
+function registerScriptTools(server, ctx) {
+  server.registerTool(
+    "list_scripts",
+    {
+      title: "List scripts",
+      description: "Return all saved automation scripts (id, name, controlType, step count).",
+    },
+    handler(async () => textResult(ctx.listScripts()))
+  );
+
+  server.registerTool(
+    "run_script",
+    {
+      title: "Run script",
+      description: "Execute a saved script by id. Blocks until the script completes or is cancelled.",
+      inputSchema: {
+        scriptId: z.string().describe("Id of the script to run."),
+      },
+    },
+    handler(async ({ scriptId }) => textResult(await ctx.runScript(scriptId)))
+  );
+
+  server.registerTool(
+    "stop_script",
+    {
+      title: "Stop script",
+      description: "Cancel the currently running script.",
+    },
+    handler(async () => textResult(ctx.stopScript()))
+  );
+
+  server.registerTool(
+    "create_script",
+    {
+      title: "Create script",
+      description:
+        "Create a script programmatically. Each step has a key, an optional mod " +
+        "(-1 keypress/keydown, 0 keypress, 100 keyup), and a delay in ms before the step.",
+      inputSchema: {
+        name: z.string().optional().describe("Optional script name."),
+        controlType: z.enum(["ecp", "adb", "atv"]).describe("Target protocol for the steps."),
+        steps: z
+          .array(
+            z.object({
+              key: z.string(),
+              mod: z.number().optional(),
+              delay: z.number().optional(),
+            })
+          )
+          .describe("Ordered list of steps to replay."),
+      },
+    },
+    handler(async ({ name, controlType, steps }) =>
+      textResult(ctx.createScript({ name, controlType, steps }))
+    )
+  );
+
+  server.registerTool(
+    "delete_script",
+    {
+      title: "Delete script",
+      description: "Remove a saved script by id.",
+      inputSchema: {
+        scriptId: z.string().describe("Id of the script to delete."),
+      },
+    },
+    handler(async ({ scriptId }) => textResult(ctx.deleteScript(scriptId)))
+  );
+}
+
+function registerDisplayTools(server, ctx) {
+  server.registerTool(
+    "show_display",
+    { title: "Show display", description: "Make the floating display window visible." },
+    handler(async () => textResult(ctx.showDisplay()))
+  );
+
+  server.registerTool(
+    "hide_display",
+    { title: "Hide display", description: "Hide the floating display window." },
+    handler(async () => textResult(ctx.hideDisplay()))
+  );
+
+  server.registerTool(
+    "toggle_fullscreen",
+    { title: "Toggle fullscreen", description: "Toggle fullscreen mode of the display window." },
+    handler(async () => textResult(ctx.toggleFullscreen()))
+  );
+
+  server.registerTool(
+    "toggle_on_top",
+    { title: "Toggle always on top", description: "Toggle always-on-top mode of the display window." },
+    handler(async () => textResult(ctx.toggleOnTop()))
+  );
+}
+
+function registerStateTools(server, ctx) {
+  server.registerTool(
+    "get_settings",
+    {
+      title: "Get settings",
+      description: "Return a read-only snapshot of the current app settings (auth token redacted).",
+    },
+    handler(async () => textResult(ctx.getSettingsSnapshot()))
+  );
+
+  server.registerTool(
+    "get_app_info",
+    {
+      title: "Get app info",
+      description: "Return app version, OS/platform, and MCP server status.",
+    },
+    handler(async () => textResult(ctx.getAppInfo()))
+  );
+}
+
+function registerResources(server, ctx) {
+  server.registerResource(
+    "devices",
+    "carabiner://devices",
+    {
+      title: "Devices",
+      description: "Current control device list and the selected device.",
+      mimeType: "application/json",
+    },
+    async (uri) => ({
+      contents: [
+        {
+          uri: uri.href,
+          mimeType: "application/json",
+          text: JSON.stringify(
+            { devices: ctx.listDevices(), current: ctx.getCurrentDevice() },
+            null,
+            2
+          ),
+        },
+      ],
+    })
+  );
+
+  server.registerResource(
+    "scripts",
+    "carabiner://scripts",
+    {
+      title: "Scripts",
+      description: "All saved automation scripts.",
+      mimeType: "application/json",
+    },
+    async (uri) => ({
+      contents: [
+        { uri: uri.href, mimeType: "application/json", text: JSON.stringify(ctx.getScripts(), null, 2) },
+      ],
+    })
+  );
+
+  server.registerResource(
+    "settings",
+    "carabiner://settings",
+    {
+      title: "Settings",
+      description: "Full settings snapshot (auth token redacted).",
+      mimeType: "application/json",
+    },
+    async (uri) => ({
+      contents: [
+        {
+          uri: uri.href,
+          mimeType: "application/json",
+          text: JSON.stringify(ctx.getSettingsSnapshot(), null, 2),
+        },
+      ],
+    })
+  );
+
+  server.registerResource(
+    "latest-screenshot",
+    "carabiner://screenshot/latest",
+    {
+      title: "Latest screenshot",
+      description: "Capture the current frame as a PNG image.",
+      mimeType: "image/png",
+    },
+    async (uri) => {
+      const shot = await ctx.takeScreenshot({ save: false });
+      return {
+        contents: [{ uri: uri.href, mimeType: shot.mimeType, blob: shot.base64 }],
+      };
+    }
+  );
+}
+
+function registerPrompts(server, ctx) {
+  server.registerPrompt(
+    "qa_navigation_test",
+    {
+      title: "QA navigation test",
+      description:
+        "Guide a structured navigation test (home → content → playback → back) capturing a " +
+        "screenshot at each step.",
+      argsSchema: {
+        app_name: z.string().optional().describe("Name of the app under test, if known."),
+      },
+    },
+    ({ app_name }) => ({
+      messages: [
+        {
+          role: "user",
+          content: {
+            type: "text",
+            text:
+              `You are running a QA navigation test on the connected streaming device${
+                app_name ? ` for the "${app_name}" app` : ""
+              } using the Carabiner MCP tools.\n\n` +
+              "Follow these steps, calling take_screenshot after each navigation and describing " +
+              "what you see before continuing:\n" +
+              "1. send_key('home') and screenshot the home screen.\n" +
+              "2. Navigate into a content row (send_key('down'), then 'right' a few times) and screenshot.\n" +
+              "3. send_key('select') to open a content detail page and screenshot.\n" +
+              "4. send_key('play') to start playback, wait ~5s, and screenshot.\n" +
+              "5. send_key('back') until you return home, screenshotting the final state.\n\n" +
+              "Report any unexpected UI state, errors, or navigation that did not behave as expected.",
+          },
+        },
+      ],
+    })
+  );
+
+  server.registerPrompt(
+    "record_script_from_description",
+    {
+      title: "Record script from description",
+      description:
+        "Turn a natural-language workflow description into a create_script steps array for the " +
+        "active protocol.",
+      argsSchema: {
+        description: z.string().describe("Natural-language description of the workflow to automate."),
+      },
+    },
+    ({ description }) => ({
+      messages: [
+        {
+          role: "user",
+          content: {
+            type: "text",
+            text:
+              "Convert the following workflow description into an automation script for the " +
+              "currently selected Carabiner device.\n\n" +
+              `Workflow: ${description}\n\n` +
+              "First call get_current_device to learn the active protocol. Then build a steps array " +
+              "where each step is { key, mod, delay } (mod 0 for a press, delay in ms before the " +
+              "step) using friendly key names, and call create_script with that protocol and steps. " +
+              "Finally call run_script to verify it, taking screenshots to confirm the result.",
+          },
+        },
+      ],
+    })
+  );
+}
+
+module.exports = { registerAll, SEMANTIC_KEYS, resolveKey };

--- a/public/render.js
+++ b/public/render.js
@@ -70,6 +70,11 @@ overlayImage.style.display = "none";
 let mediaRecorder = null;
 let recordedChunks = [];
 let isRecording = false;
+// When recording is driven by the MCP server, save without a dialog and report the path back.
+let mcpRecording = false;
+let mcpRecordingPrefix = "";
+let mcpStopRecordingResolve = null;
+let mcpStopRecordingReject = null;
 
 // Device monitoring variables
 let currentDeviceList = [];
@@ -976,9 +981,24 @@ window.addEventListener("DOMContentLoaded", function () {
     }
   }
 
+  function settleMcpRecording(error, filePath) {
+    const resolve = mcpStopRecordingResolve;
+    const reject = mcpStopRecordingReject;
+    mcpStopRecordingResolve = null;
+    mcpStopRecordingReject = null;
+    mcpRecording = false;
+    mcpRecordingPrefix = "";
+    if (error) {
+      reject?.(error instanceof Error ? error : new Error(String(error)));
+    } else {
+      resolve?.({ filePath });
+    }
+  }
+
   async function saveRecording() {
     if (recordedChunks.length === 0) {
       showToast("No recording data to save!", 5000, true);
+      if (mcpRecording) settleMcpRecording(new Error("No recording data to save."));
       return;
     }
 
@@ -995,7 +1015,8 @@ window.addEventListener("DOMContentLoaded", function () {
         extension = "webm";
       }
 
-      const filename = `carabiner-recording-${datePart}-${timePart}.${extension}`;
+      const prefix = mcpRecording && mcpRecordingPrefix ? mcpRecordingPrefix : "carabiner-recording";
+      const filename = `${prefix}-${datePart}-${timePart}.${extension}`;
 
       // Convert blob to buffer for saving
       const arrayBuffer = await blob.arrayBuffer();
@@ -1003,6 +1024,22 @@ window.addEventListener("DOMContentLoaded", function () {
 
       // Convert to regular array for IPC serialization
       const bufferData = Array.from(uint8Array);
+
+      // MCP-driven recording: save without a dialog and report the path back to the caller.
+      if (mcpRecording) {
+        const directResult = await window.electronAPI.invoke("save-video-direct", filename, bufferData);
+        recordedChunks = [];
+        if (directResult.success) {
+          showToast(`Recording saved as ${filename}.`, 5000, false, () => {
+            window.electronAPI.invoke("open-containing-folder", directResult.filePath);
+          });
+          settleMcpRecording(null, directResult.filePath);
+        } else {
+          showToast("Failed to save recording!", 5000, true);
+          settleMcpRecording(new Error(directResult.error || "Failed to save recording."));
+        }
+        return;
+      }
 
       // Show save dialog and save file
       const result = await window.electronAPI.invoke("save-video-dialog", filename, bufferData);
@@ -1030,12 +1067,68 @@ window.addEventListener("DOMContentLoaded", function () {
       console.error("[Carabiner] Error saving recording:", error);
       showToast("Failed to save recording!", 5000, true);
       recordedChunks = [];
+      if (mcpRecording) settleMcpRecording(error);
     }
   }
 
   // Handle copy and save screenshot requests
   window.electronAPI.onMessageReceived("copy-screenshot", handleCopyScreenshot);
   window.electronAPI.onMessageReceived("save-screenshot", handleSaveScreenshot);
+
+  // Handle MCP server requests routed through the main process (request/response RPC).
+  window.electronAPI.onMessageReceived("mcp-rpc-request", async (_, { requestId, action, params }) => {
+    try {
+      let result;
+      switch (action) {
+        case "capture-screenshot": {
+          if (!videoPlayer || !videoPlayer.videoWidth) {
+            throw new Error("No active video stream to capture.");
+          }
+          result = getScreenshotCanvas().toDataURL("image/png");
+          break;
+        }
+        case "send-key":
+          sendKey(params.key, params.mod ?? 0);
+          result = { sent: params.key };
+          break;
+        case "send-text":
+          await typeText(params.text);
+          result = { sent: params.text };
+          break;
+        case "start-recording": {
+          if (isRecording) throw new Error("Already recording.");
+          if (!videoPlayer || !videoPlayer.srcObject) {
+            throw new Error("No active video stream to record.");
+          }
+          mcpRecording = true;
+          mcpRecordingPrefix = params?.filenamePrefix || "";
+          handleStartRecording();
+          if (!isRecording) {
+            mcpRecording = false;
+            mcpRecordingPrefix = "";
+            throw new Error("Failed to start recording.");
+          }
+          result = { recording: true };
+          break;
+        }
+        case "stop-recording": {
+          if (!isRecording) throw new Error("Not currently recording.");
+          const done = new Promise((resolve, reject) => {
+            mcpStopRecordingResolve = resolve;
+            mcpStopRecordingReject = reject;
+          });
+          handleStopRecording();
+          result = await done; // { filePath }
+          break;
+        }
+        default:
+          throw new Error(`Unknown MCP action: ${action}`);
+      }
+      window.electronAPI.send("mcp-rpc-response", { requestId, result });
+    } catch (error) {
+      window.electronAPI.send("mcp-rpc-response", { requestId, error: error.message });
+    }
+  });
 
   // Listen for the image-loaded event
   window.electronAPI.onMessageReceived("image-loaded", (event, imageData) => {

--- a/public/settings.js
+++ b/public/settings.js
@@ -33,6 +33,11 @@ function loadSettings() {
       recordingPath: "", // Empty string means use default (Movies on macOS, Videos elsewhere)
     },
     scripts: [],
+    mcp: {
+      enabled: false, // MCP server disabled by default
+      port: 7734, // Localhost port the MCP server listens on
+      token: "", // Optional Bearer token; empty means no authentication
+    },
   };
   try {
     return Object.assign(defaultSettings, JSON.parse(fs.readFileSync(settingsFilePath)));

--- a/src/App.js
+++ b/src/App.js
@@ -21,6 +21,7 @@ import OverlaySection from "./components/OverlaySection";
 import FilesSection from "./components/FilesSection";
 import AboutSection from "./components/AboutSection";
 import AutomationSection from "./components/AutomationSection";
+import MCPSection from "./components/MCPSection";
 
 const { electronAPI } = window;
 
@@ -104,6 +105,11 @@ function App() {
           <Tab eventKey="automation" title="Automation">
             <div className="tab-content-container">
               <AutomationSection />
+            </div>
+          </Tab>
+          <Tab eventKey="mcp" title="MCP">
+            <div className="tab-content-container">
+              <MCPSection />
             </div>
           </Tab>
           <Tab eventKey="overlay" title="Overlay">

--- a/src/components/MCPSection.js
+++ b/src/components/MCPSection.js
@@ -1,0 +1,133 @@
+/*---------------------------------------------------------------------------------------------
+ *  Carabiner - Simple Screen Capture and Remote Control App for Streaming Devices
+ *
+ *  Repository: https://github.com/lvcabral/carabiner
+ *
+ *  Copyright (c) 2024-2026 Marcelo Lv Cabral. All Rights Reserved.
+ *
+ *  Licensed under the MIT License. See LICENSE in the repository root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import { useEffect, useState } from "react";
+import { Container, Form, Row, Col, Card } from "react-bootstrap";
+
+const { electronAPI } = window;
+
+const DOCS_URL = "https://github.com/lvcabral/carabiner/blob/main/docs/mcp-server.md";
+
+function MCPSection() {
+  const [enabled, setEnabled] = useState(false);
+  const [port, setPort] = useState(7734);
+  const [token, setToken] = useState("");
+  const [status, setStatus] = useState({ running: false });
+
+  useEffect(() => {
+    electronAPI.invoke("load-settings").then((settings) => {
+      if (settings.mcp) {
+        setEnabled(settings.mcp.enabled ?? false);
+        setPort(settings.mcp.port ?? 7734);
+        setToken(settings.mcp.token ?? "");
+      }
+    });
+    electronAPI.invoke("get-mcp-status").then(setStatus);
+  }, []);
+
+  const saveConfig = (overrides = {}) => {
+    const config = { enabled, port, token, ...overrides };
+    electronAPI.invoke("save-mcp-config", config).then((result) => {
+      if (result) {
+        setStatus(result);
+      }
+    });
+  };
+
+  const handleEnabledChange = (e) => {
+    const value = e.target.checked;
+    setEnabled(value);
+    saveConfig({ enabled: value });
+  };
+
+  const handleLinkClick = (event) => {
+    event.preventDefault();
+    electronAPI.openExternal(event.currentTarget.href);
+  };
+
+  return (
+    <Container fluid className="p-2">
+      <Card>
+        <Card.Body>
+          <Form.Group>
+            <div className="d-flex justify-content-between align-items-center">
+              <Form.Label className="mb-0">MCP Server</Form.Label>
+              <Form.Check
+                type="switch"
+                id="mcp-enabled-switch"
+                label="Enable"
+                checked={enabled}
+                onChange={handleEnabledChange}
+              />
+            </div>
+            <Form.Text className="text-muted" style={{ fontSize: "0.8rem" }}>
+              Let AI assistants control Carabiner via the Model Context Protocol (binds to localhost
+              only).
+            </Form.Text>
+          </Form.Group>
+          <Row className="mt-2">
+            <Col xs={4}>
+              <Form.Label>Port</Form.Label>
+              <Form.Control
+                type="number"
+                value={port}
+                disabled={enabled}
+                onChange={(e) => setPort(parseInt(e.target.value, 10) || 7734)}
+                onBlur={() => saveConfig()}
+              />
+            </Col>
+            <Col xs={8}>
+              <Form.Label>Auth Token (optional)</Form.Label>
+              <Form.Control
+                type="password"
+                value={token}
+                disabled={enabled}
+                placeholder="Leave empty to disable authentication"
+                onChange={(e) => setToken(e.target.value)}
+                onBlur={() => saveConfig()}
+              />
+            </Col>
+          </Row>
+          <Form.Text className="text-muted mt-2 d-block">
+            {status.running
+              ? `Running — connect MCP clients to http://localhost:${status.port}/mcp`
+              : "Stopped"}
+          </Form.Text>
+        </Card.Body>
+      </Card>
+
+      <Card className="mt-2">
+        <Card.Body style={{ fontSize: "0.8rem" }}>
+          <Card.Title as="h6" style={{ fontSize: "0.85rem" }}>
+            Using the MCP Server
+          </Card.Title>
+          <p className="mb-2 text-muted">
+            Enable the server above, then point an MCP client (Claude Code, Cursor, …) at it.
+          </p>
+          <p className="mb-1 text-muted">
+            The AI agent can then select devices, send keys, take screenshots, run automation
+            scripts, and validate UI state — and you can schedule recurring QA runs externally.
+          </p>
+          <p className="mb-0">
+            <a
+              href={DOCS_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={handleLinkClick}
+              style={{ textDecoration: "none" }}
+            > 📖 Read the full MCP Server documentation on GitHub
+            </a>
+          </p>
+        </Card.Body>
+      </Card>
+    </Container>
+  );
+}
+
+export default MCPSection;


### PR DESCRIPTION
## Overview

Implements **issue #88**: embeds a [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server in Carabiner's Electron main process so AI assistants (Claude Code, Cursor, Claude Desktop, …) can programmatically control streaming devices, run automation scripts, manage recordings, and read live app state. This turns Carabiner into an AI-native QA tool.

Per updated direction on the issue, the in-app scheduler (#87) is **out of scope** — scheduling is handled externally by an AI agent driving the MCP server, and is documented instead.

## What's included

- **`public/mcp-server.js`** — server bound to **`127.0.0.1` only**, serving both **Streamable HTTP at `/mcp`** (recommended) and **legacy SSE at `/sse`**, with optional **Bearer-token auth**. Starts/stops live with the settings toggle and shuts down on `before-quit`. The MCP SDK ships a CJS build, so it's `require`d directly.
- **`public/mcp-tools.js`** — **21 tools, 4 resources, 2 prompts**, all thin wrappers over a `ctx` bridge that reuses the existing IPC internals (no duplicated device logic). Includes a friendly→native key map for `send_key`.
- **`public/main.js`** — `callDisplay()` renderer RPC (`mcp-rpc-request`/`mcp-rpc-response`), `run-script` refactored into a shared `startScriptPlayback()` so MCP `run_script` blocks until `script-playback-done`, non-dialog `save-video-direct`, `selectDevice`/`selectCaptureDevice`, and `save-mcp-config`/`get-mcp-status` IPC.
- **`public/render.js`** — `mcp-rpc-request` handler for canvas screenshot, key/text send, and dialog-less recording save.
- **Settings + UI** — `mcp: { enabled, port: 7734, token }` defaults and a dedicated **MCP** settings tab (`MCPSection`) with config + usage instructions and a docs link.
- **Docs** — `docs/mcp-server.md` (setup, `.mcp.json`, full tool reference, agent QA examples, and **external scheduling via `claude -p` in cron / `/loop`**), plus README / usage-guide / CLAUDE.md updates. A root `.mcp.json` is included so the project connects out of the box.

## Acceptance criteria

- [x] MCP server starts/stops via settings toggle without app restart
- [x] All tools listed in the issue implemented and documented
- [x] Server binds to localhost only
- [x] Claude Code can discover and use the server via `.mcp.json`
- [x] New settings fields appear in the UI (own MCP tab)
- [x] Optional Bearer-token authentication

## Testing

React build compiles; all main-process files pass `node --check`. Verified end-to-end against the **live running app** with a real MCP client:

- Discovery: 21 tools / 4 resources / 2 prompts.
- `list_devices` (4 Roku/ECP, Google TV + Fire TV/ADB, Apple TV/ATV), `get_current_device`, `list_capture_devices`, `list_scripts`, `get_settings` (token redacted).
- `send_key("home")` navigated the Roku (friendly name → ECP keypress).
- `take_screenshot` → **1920×1080 PNG** saved to `~/Pictures`; `carabiner://screenshot/latest` returned a PNG blob.
- `create_script` + `delete_script` round-trip (real scripts untouched).
- `start_recording` → `stop_recording` → **valid MP4** saved to `~/Movies`.
- Auth: connections without the Bearer token rejected with 401; correct token accepted.

Closes #88.

🤖 Generated with [Claude Code](https://claude.com/claude-code)