### PR TITLE
Fix macOS not sleeping when audio enabled (#91)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -95,6 +95,7 @@ Key message types handled in `main.js`:
 - `set-adb-path` / `set-atv-path` — update paths to the `adb` and `atvremote` binaries
 - `set-audio-enabled` — toggles audio in the display window
 - `set-show-keystrokes` — toggles the on-screen key indicator overlay
+- `set-allow-sleep` — toggles the `powerMonitor`-based auto-pause that lets the machine sleep (see Allow Mac to Sleep)
 
 Separate `ipcMain.on`/`ipcMain.handle` channels (outside `shared-window-channel`) handle:
 - Script recording lifecycle: `start-script-recording`, `stop-script-recording`, `save-script`, `run-script`, `stop-script`, `script-playback-started`, `script-playback-done`
@@ -126,3 +127,7 @@ The device ID string format encodes protocol: `"<ip>|ecp"`, `"<ip>|adb"`, or `"<
 ### Show Keystrokes Overlay
 
 When `showKeystrokes` is enabled (`set-show-keystrokes` IPC message or `display.showKeystrokes` setting), `render.js` calls `displayKeyIndicator()` to show a brief on-screen label for each key press — useful during live presentations or screen recordings.
+
+### Allow Mac to Sleep
+
+Live audio capture/playback (and the playing `<video>`) make macOS hold `PreventUserIdleSystemSleep` (via `coreaudiod`) and a Chromium "Video Wake Lock" (`NoDisplaySleepAssertion`), which keep the machine awake while Carabiner streams. The app can't suppress those assertions directly — the only way to release them is to stop capturing. This is macOS-only: the toggle is hidden on Windows/Linux (`DisplaySection.js`) and the watcher only starts when `isMacOS`. When `display.allowSleep` is enabled (default; toggle in the Display tab → `set-allow-sleep`), `main.js` registers a `powerMonitor` watcher: it pauses capture on `lock-screen` or after `IDLE_SLEEP_SECONDS` (5 min, via polling `getSystemIdleTime()`), and resumes on `unlock-screen` / activity. Pause/resume reuse the display window's existing `stopVideoStream()`/`renderDisplay()` via the dedicated `auto-suspend`/`auto-resume` IPC messages (kept separate from `window-hide`/`window-show`). The watcher is started/stopped live when the toggle changes and torn down on `before-quit`.

--- a/public/main.js
+++ b/public/main.js
@@ -18,6 +18,7 @@ const {
   Notification,
   systemPreferences,
   globalShortcut,
+  powerMonitor,
   screen,
   shell,
 } = require("electron");
@@ -340,7 +341,64 @@ app.whenReady().then(async () => {
   const mainWindow = createMainWindow();
   const displayWindow = createDisplayWindow();
   setAlwaysOnTop(settings.display.alwaysOnTop ?? true, displayWindow);
+
+  // --- Allow Mac to sleep (issue #91) ---------------------------------------
+  // Live audio I/O (and the playing <video>) cause macOS to hold
+  // PreventUserIdleSystemSleep / "Video Wake Lock" assertions, which keep the
+  // machine awake. The app can't suppress those assertions directly, so when
+  // the user locks the screen or goes idle we pause the capture stream (which
+  // releases them) and resume it on unlock / activity. Controlled by
+  // settings.display.allowSleep (default on).
+  const IDLE_SLEEP_SECONDS = 300; // pause capture after 5 minutes idle
+  const IDLE_POLL_MS = 30000; // check idle time every 30 seconds
+  let sleepWatcherInterval = null;
+  let autoSuspended = false;
+
+  function suspendCapture() {
+    if (autoSuspended || !displayWindow || displayWindow.isDestroyed()) return;
+    autoSuspended = true;
+    displayWindow.webContents.send("auto-suspend");
+  }
+
+  function resumeCapture() {
+    if (!autoSuspended) return;
+    autoSuspended = false;
+    if (displayWindow && !displayWindow.isDestroyed() && displayWindow.isVisible()) {
+      displayWindow.webContents.send("auto-resume");
+    }
+  }
+
+  function pollSystemIdle() {
+    if (powerMonitor.getSystemIdleTime() >= IDLE_SLEEP_SECONDS) {
+      suspendCapture();
+    } else if (autoSuspended) {
+      resumeCapture();
+    }
+  }
+
+  function startSleepWatcher() {
+    if (sleepWatcherInterval) return;
+    powerMonitor.on("lock-screen", suspendCapture);
+    powerMonitor.on("unlock-screen", resumeCapture);
+    sleepWatcherInterval = setInterval(pollSystemIdle, IDLE_POLL_MS);
+  }
+
+  function stopSleepWatcher() {
+    if (sleepWatcherInterval) {
+      clearInterval(sleepWatcherInterval);
+      sleepWatcherInterval = null;
+    }
+    powerMonitor.removeListener("lock-screen", suspendCapture);
+    powerMonitor.removeListener("unlock-screen", resumeCapture);
+    if (autoSuspended) resumeCapture();
+  }
+
   if (isMacOS) {
+    // macOS only: this works around the macOS audio/video sleep assertions and the
+    // toggle is hidden on other platforms (see DisplaySection.js).
+    if (settings.display?.allowSleep !== false) {
+      startSleepWatcher();
+    }
     createMacOSMenu(mainWindow, displayWindow, packageInfo, settings);
     // Ensure menu reflects the correct always on top state from settings
     updateAlwaysOnTopMenuItem(settings.display.alwaysOnTop ?? true);
@@ -719,6 +777,14 @@ app.whenReady().then(async () => {
     } else if (arg.type && arg.type === "set-show-keystrokes") {
       settings.display.showKeystrokes = arg.payload;
       saveFlag = true;
+    } else if (arg.type && arg.type === "set-allow-sleep") {
+      settings.display.allowSleep = arg.payload;
+      saveFlag = true;
+      if (arg.payload) {
+        startSleepWatcher();
+      } else {
+        stopSleepWatcher();
+      }
     } else if (arg.type && arg.type === "clear-overlay-image") {
       saveFlag = false;
       // Clear the overlay image by sending a specific clear message
@@ -1421,6 +1487,7 @@ app.whenReady().then(async () => {
   });
   app.on("before-quit", () => {
     isQuitting = true;
+    stopSleepWatcher();
     if (isMcpRunning()) {
       stopMcpServer();
     }

--- a/public/render.js
+++ b/public/render.js
@@ -479,6 +479,28 @@ window.addEventListener("DOMContentLoaded", function () {
   // Ensure the display window gets focus when it loads
   window.focus();
 
+  // Auto-pause capture so the Mac can sleep (issue #91). Main triggers these on
+  // screen lock / user idle, and resume on unlock / activity. Kept separate from
+  // window-hide/show so it doesn't disturb script recording or window state.
+  window.electronAPI.onMessageReceived("auto-suspend", () => {
+    if (videoState !== "stopped") {
+      stopVideoStream();
+    }
+  });
+
+  window.electronAPI.onMessageReceived("auto-resume", () => {
+    if (videoState === "stopped" && currentConstraints && currentConstraints.video) {
+      const hasSpecificDevice =
+        currentConstraints.video !== true &&
+        typeof currentConstraints.video === "object" &&
+        currentConstraints.video.deviceId;
+
+      if (hasSpecificDevice) {
+        renderDisplay(currentConstraints);
+      }
+    }
+  });
+
   // Handle window visibility changes via Electron IPC events
   window.electronAPI.onMessageReceived("window-show", () => {
     // Window is now visible - restart video stream if we have constraints and it's stopped

--- a/src/components/DisplaySection.js
+++ b/src/components/DisplaySection.js
@@ -51,6 +51,7 @@ const getPredefinedSizes = (maxWidth, maxHeight) => {
 };
 
 function DisplaySection() {
+  const isMacOS = navigator.platform.toUpperCase().indexOf("MAC") >= 0;
   const [borderWidth, setBorderWidth] = useState("0.1px");
   const [borderStyle, setBorderStyle] = useState("solid");
   const [borderColor, setBorderColor] = useState("#662D91");
@@ -59,6 +60,7 @@ function DisplaySection() {
   const [transparency, setTransparency] = useState(0);
   const [alwaysOnTop, setAlwaysOnTop] = useState(true);
   const [showKeystrokes, setShowKeystrokes] = useState(false);
+  const [allowSleep, setAllowSleep] = useState(true);
   const [mainDisplaySize, setMainDisplaySize] = useState({
     width: 1920,
     height: 1080,
@@ -103,6 +105,9 @@ function DisplaySection() {
         }
         if (settings.display && settings.display.showKeystrokes !== undefined) {
           setShowKeystrokes(settings.display.showKeystrokes);
+        }
+        if (settings.display && settings.display.allowSleep !== undefined) {
+          setAllowSleep(settings.display.allowSleep);
         }
 
         // Set display size based on current window size and filtered predefined options
@@ -187,6 +192,14 @@ function DisplaySection() {
     setShowKeystrokes(e.target.checked);
     electronAPI.sendSync("shared-window-channel", {
       type: "set-show-keystrokes",
+      payload: e.target.checked,
+    });
+  };
+
+  const handleAllowSleepChange = (e) => {
+    setAllowSleep(e.target.checked);
+    electronAPI.sendSync("shared-window-channel", {
+      type: "set-allow-sleep",
       payload: e.target.checked,
     });
   };
@@ -291,6 +304,15 @@ function DisplaySection() {
                     onChange={handleShowKeystrokesChange}
                     className="text-nowrap mt-2"
                   />
+                  {isMacOS && (
+                    <Form.Check
+                      type="checkbox"
+                      label="Allow Mac to Sleep"
+                      checked={allowSleep}
+                      onChange={handleAllowSleepChange}
+                      className="text-nowrap mt-2"
+                    />
+                  )}
                 </div>
               </div>
             </Col>


### PR DESCRIPTION
## Summary

Fixes #91 — with Carabiner running and audio enabled, the Mac never went to sleep.

The `pmset -g assertions` log in the issue shows the real cause:
- **`coreaudiod`** holds two `PreventUserIdleSystemSleep` assertions — one for the audio **output** (playing the captured audio) and one for the audio **input** (the USB capture card). macOS asserts these automatically whenever there's active audio I/O.
- **Carabiner** itself only holds a `NoDisplaySleepAssertion` ("Video Wake Lock"), Chromium's automatic *display*-sleep lock for the playing `<video>`.

The app can't suppress those assertions directly (Chromium denies all `system` wake-lock requests, and the audio assertions are inherent macOS behavior). The only way to let the Mac sleep is to **stop capturing**.

## Changes

- **`public/main.js`** — macOS-only `powerMonitor` watcher: pauses capture on `lock-screen` or after 5 min idle (`getSystemIdleTime()`, polled every 30s), resumes on `unlock-screen`/activity. Started/stopped live via the new `set-allow-sleep` IPC case and torn down on `before-quit`. Auto-resume is guarded by `displayWindow.isVisible()` so it won't override a manually-hidden window.
- **`public/render.js`** — dedicated `auto-suspend`/`auto-resume` listeners that reuse the existing `stopVideoStream()`/`renderDisplay()`, kept separate from `window-hide`/`window-show` so script recording and window state aren't disturbed.
- **`src/components/DisplaySection.js`** — "Allow Mac to Sleep" toggle (default ON), persisted to `settings.display.allowSleep`. Hidden on Windows/Linux.
- **`.claude/CLAUDE.md`** — documents the new IPC message and behavior.

## Test plan

1. With a capture device + audio enabled, run `pmset -g assertions`; confirm the `coreaudiod` `PreventUserIdleSystemSleep` and Carabiner `Video Wake Lock` assertions are present while streaming.
2. Lock the screen → re-run `pmset -g assertions`: assertions clear (capture paused). Unlock → stream resumes.
3. Leave idle past 5 min → assertions clear; move the mouse → stream resumes.
4. Toggle "Allow Mac to Sleep" OFF → lock screen → assertions remain. Toggle ON → auto-pause resumes.
5. Confirm setting persists across restart and that the toggle does not appear on Windows/Linux.

🤖 Generated with [Claude Code](https://claude.com/claude-code)