### PR TITLE
Add skip-version option and reorganize menus with Check for Updates

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -454,7 +454,7 @@ app.whenReady().then(async () => {
     // Check for updates 30 seconds after app start
     setTimeout(async () => {
       try {
-        await checkForUpdates();
+        await checkForUpdates(settings);
       } catch (error) {
         console.error("Error checking for updates:", error);
       }
@@ -464,7 +464,7 @@ app.whenReady().then(async () => {
     setInterval(
       async () => {
         try {
-          await checkForUpdates();
+          await checkForUpdates(settings);
         } catch (error) {
           console.error("Error checking for updates:", error);
         }
@@ -866,6 +866,14 @@ app.whenReady().then(async () => {
   ipcMain.on("save-check-for-updates", (event, checkForUpdates) => {
     settings.display.autoUpdate = checkForUpdates;
     saveSettings(settings);
+  });
+
+  // Manual "Check for Updates" triggered from a menu — always runs (even in dev)
+  // and gives the user feedback when there is nothing to download.
+  ipcMain.on("check-for-updates", () => {
+    checkForUpdates(settings, true).catch((error) => {
+      console.error("Error checking for updates:", error);
+    });
   });
 
   ipcMain.on("save-show-in-dock", (event, showInDock) => {

--- a/public/menu.js
+++ b/public/menu.js
@@ -270,6 +270,14 @@ const HelpMenuItems = {
     click: () => shell.openExternal(`${packageInfo.repository.url}/issues`),
   }),
 
+  checkForUpdates: () => ({
+    label: "Check for Updates...",
+    click: () => {
+      const { ipcMain } = require("electron");
+      ipcMain.emit("check-for-updates");
+    },
+  }),
+
   about: (mainWindow) => ({
     label: "About Carabiner",
     click: () => {
@@ -279,12 +287,30 @@ const HelpMenuItems = {
   }),
 };
 
+// Builds the shared "Help" submenu used by the tray and context (popup) menus.
+function buildHelpSubmenu(packageInfo, { includeReleaseNotes = false, includeCheckForUpdates = false } = {}) {
+  const items = [
+    HelpMenuItems.documentation(packageInfo),
+    HelpMenuItems.keyboardControl(packageInfo),
+    MenuItems.separator(),
+    HelpMenuItems.reportBug(packageInfo),
+  ];
+  if (includeReleaseNotes) {
+    items.push(MenuItems.separator(), HelpMenuItems.releaseNotes(packageInfo));
+  }
+  if (includeCheckForUpdates) {
+    items.push(MenuItems.separator(), HelpMenuItems.checkForUpdates());
+  }
+  return items;
+}
+
 // Platform-specific application menu items
 const AppMenuItems = {
   macOS: (mainWindow) => ({
     label: app.getName(),
     submenu: [
       HelpMenuItems.about(mainWindow),
+      HelpMenuItems.checkForUpdates(),
       MenuItems.separator(),
       MenuItems.settings(mainWindow),
       MenuItems.separator(),
@@ -562,11 +588,13 @@ function createTrayMenu(
     new MenuItem(MenuItems.separator()),
     new MenuItem(MenuItems.settings(mainWindow)),
     new MenuItem(MenuItems.separator()),
-    new MenuItem(HelpMenuItems.reportBug(packageInfo)),
-    new MenuItem(MenuItems.separator()),
-    new MenuItem(HelpMenuItems.documentation(packageInfo)),
-    new MenuItem(HelpMenuItems.keyboardControl(packageInfo)),
-    new MenuItem(HelpMenuItems.releaseNotes(packageInfo)),
+    new MenuItem({
+      label: "Help",
+      submenu: buildHelpSubmenu(packageInfo, {
+        includeReleaseNotes: true,
+        includeCheckForUpdates: true,
+      }),
+    }),
     new MenuItem(MenuItems.separator()),
     new MenuItem({ role: "quit" }),
   ];
@@ -747,10 +775,10 @@ function createContextMenu(
     new MenuItem(MenuItems.separator()),
     new MenuItem(MenuItems.settings(mainWindow)),
     new MenuItem(MenuItems.separator()),
-    new MenuItem(HelpMenuItems.reportBug(packageInfo)),
-    new MenuItem(MenuItems.separator()),
-    new MenuItem(HelpMenuItems.documentation(packageInfo)),
-    new MenuItem(HelpMenuItems.keyboardControl(packageInfo)),
+    new MenuItem({
+      label: "Help",
+      submenu: buildHelpSubmenu(packageInfo),
+    }),
     new MenuItem(MenuItems.devTools(displayWindow)),
     new MenuItem(MenuItems.separator()),
     new MenuItem({ role: "quit" }),

--- a/public/updater.js
+++ b/public/updater.js
@@ -10,10 +10,43 @@
 const { dialog, BrowserWindow, shell } = require("electron");
 const https = require("https");
 const packageInfo = require("../package.json");
+const { saveSettings } = require("./settings");
 
 let updateAvailable = false;
 let latestVersion = null;
 let dialogShown = false;
+
+// Resolve the best window to parent a dialog to: the display window if visible,
+// otherwise the settings window (may be hidden, which is fine for a dialog parent).
+function getTargetWindow() {
+  const mainWindow = BrowserWindow.getAllWindows().find((win) =>
+    win.webContents.getURL().includes("index.html")
+  );
+  const displayWindow = BrowserWindow.getAllWindows().find((win) =>
+    win.webContents.getURL().includes("display.html")
+  );
+  if (displayWindow && displayWindow.isVisible()) return displayWindow;
+  return mainWindow || null;
+}
+
+// Show a message box, parented to a window when one is available.
+function showDialog(options) {
+  const targetWindow = getTargetWindow();
+  return targetWindow
+    ? dialog.showMessageBox(targetWindow, options)
+    : dialog.showMessageBox(options);
+}
+
+// Feedback shown when a manual update check could not reach GitHub.
+function showUpdateError() {
+  showDialog({
+    type: "error",
+    title: "Update Check Failed",
+    message: "Could not check for updates.",
+    detail: "Please check your internet connection and try again.",
+    buttons: ["OK"],
+  });
+}
 
 // Function to compare version strings
 function compareVersions(current, latest) {
@@ -33,8 +66,11 @@ function compareVersions(current, latest) {
   return 0; // Same version
 }
 
-// Function to check for updates via GitHub API
-function checkForUpdates() {
+// Function to check for updates via GitHub API.
+// When `interactive` is true (a manual "Check for Updates" from a menu), the dialog
+// is always shown (ignoring a previously skipped version) and the user is given
+// "up to date" / error feedback when there is nothing to download.
+function checkForUpdates(settings, interactive = false) {
   console.log("Checking for updates...");
   return new Promise((resolve, reject) => {
     // Get repository info from package.json
@@ -74,23 +110,14 @@ function checkForUpdates() {
             if (compareVersions(currentVersion, latestVersion) === 1) {
               updateAvailable = true;
 
-              // Notify user about available update (only if not already shown)
-              const mainWindow = BrowserWindow.getAllWindows().find((win) =>
-                win.webContents.getURL().includes("index.html")
-              );
-              const displayWindow = BrowserWindow.getAllWindows().find((win) =>
-                win.webContents.getURL().includes("display.html")
-              );
+              const targetWindow = getTargetWindow();
 
-              // Prioritize displayWindow if visible, otherwise use mainWindow
-              let targetWindow = null;
-              if (displayWindow && displayWindow.isVisible()) {
-                targetWindow = displayWindow;
-              } else if (mainWindow) {
-                targetWindow = mainWindow;
-              }
+              // Honor a previously skipped version - don't nag about it again.
+              // A manual (interactive) check always prompts, ignoring the skip.
+              const skippedVersion = settings && settings.display && settings.display.skipVersion;
+              const shouldPrompt = interactive || (!dialogShown && skippedVersion !== latestVersion);
 
-              if (targetWindow && !dialogShown) {
+              if (targetWindow && shouldPrompt) {
                 dialogShown = true;
                 dialog
                   .showMessageBox(targetWindow, {
@@ -99,14 +126,19 @@ function checkForUpdates() {
                     message: `A new version (${latestVersion}) is available!`,
                     detail:
                       "Click 'Download' to visit the releases page and download the latest version.",
-                    buttons: ["Download", "Later"],
+                    buttons: ["Download", "Skip This Version", "Later"],
                     defaultId: 0,
+                    cancelId: 2,
                   })
                   .then((result) => {
                     if (result.response === 0) {
                       // User chose to download - open releases page
                       const repoUrl = packageInfo.repository.url.replace(/\.git$/, "");
                       shell.openExternal(`${repoUrl}/releases/latest`);
+                    } else if (result.response === 1 && settings && settings.display) {
+                      // User chose to skip this version - persist it so we stop prompting
+                      settings.display.skipVersion = latestVersion;
+                      saveSettings(settings);
                     }
                     // Reset flag when dialog is dismissed
                     dialogShown = false;
@@ -117,14 +149,28 @@ function checkForUpdates() {
             } else {
               updateAvailable = false;
               console.log("No updates available");
+
+              // Reassure the user when they triggered the check manually
+              if (interactive) {
+                showDialog({
+                  type: "info",
+                  title: "No Updates Available",
+                  message: "You're up to date!",
+                  detail: `Carabiner ${currentVersion} is the latest version.`,
+                  buttons: ["OK"],
+                });
+              }
+
               resolve({ updateAvailable: false, version: currentVersion });
             }
           } else {
             console.error("Failed to fetch release info:", res.statusCode, data);
+            if (interactive) showUpdateError();
             reject(new Error(`HTTP ${res.statusCode}: ${data}`));
           }
         } catch (error) {
           console.error("Error parsing release data:", error);
+          if (interactive) showUpdateError();
           reject(error);
         }
       });
@@ -132,11 +178,13 @@ function checkForUpdates() {
 
     req.on("error", (error) => {
       console.error("Error checking for updates:", error);
+      if (interactive) showUpdateError();
       reject(error);
     });
 
     req.setTimeout(10000, () => {
       req.destroy();
+      if (interactive) showUpdateError();
       reject(new Error("Request timeout"));
     });
 


### PR DESCRIPTION
## Summary

Adds a way to skip an update notification and reorganizes the tray/popup menus, plus a manual "Check for Updates" action.

### Update dialog: Skip This Version
- The "Update Available" dialog now offers three buttons: **Download**, **Skip This Version**, **Later**.
- Choosing **Skip This Version** persists the version to `settings.display.skipVersion`. Future auto-checks suppress the dialog for that release (`skippedVersion !== latestVersion`), so the user isn't nagged again — but the prompt reappears automatically once a newer version ships.

### Manual "Check for Updates"
- New `check-for-updates` IPC handler calls `checkForUpdates(settings, true)`. The `interactive` flag:
  - always shows the dialog (bypassing a previously skipped version),
  - shows a "You're up to date!" message when there's no newer release,
  - shows an error dialog if the GitHub check fails.
- Runs even in dev builds (not gated behind `app.isPackaged`), which also makes the update flow testable without packaging.

### Menu reorganization
- **macOS app menu**: added **Check for Updates…** directly under **About Carabiner**.
- **Tray menu**: help items (Usage Guide, Keyboard Control, Report a Bug, Release Notes) grouped into a **Help** submenu, with **Check for Updates…** added.
- **Popup/context menu**: help items grouped into a **Help** submenu; **Developer Tools** kept separate.
- Added shared `buildHelpSubmenu()` helper and refactored duplicated window-lookup logic in the updater into `getTargetWindow()`/`showDialog()`.

## Test plan
- [ ] Lower the local `package.json` version, run the app, trigger **Check for Updates** → dialog appears with the three buttons.
- [ ] Click **Skip This Version** → `skipVersion` written to `settings.json`; auto-check no longer prompts for that version.
- [ ] Manual **Check for Updates** still prompts even after skipping.
- [ ] With current version up to date → manual check shows "You're up to date!".
- [ ] Verify Help submenu grouping in tray and popup menus on macOS and Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)