### PR TITLE
Add Xumo Stream Box (RDK) device control

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -28,6 +28,14 @@ const { saveSettings, loadSettings } = require("./settings");
 const { connectADB, disconnectADB, sendADBKey, sendADBText } = require("./adb");
 const { connectATV, disconnectATV, sendATVKey, sendATVText } = require("./appletv");
 const {
+  connectRDK,
+  disconnectRDK,
+  sendRDKKey,
+  sendRDKText,
+  launchRDKApp,
+  testRDKConnection,
+} = require("./rdk");
+const {
   createMacOSMenu,
   updateAlwaysOnTopMenuItem,
   updateEnableAudioMenuItem,
@@ -62,6 +70,7 @@ let controlIp = "";
 let controlType = "";
 let isADBConnected = false;
 let isATVConnected = false;
+let isRDKConnected = false;
 let isQuitting = false;
 let captureDevices;
 let isCurrentlyRecording = false;
@@ -445,6 +454,19 @@ app.whenReady().then(async () => {
     }
   }
 
+  if (
+    typeof settings?.control?.deviceId === "string" &&
+    settings.control.deviceId.includes("|rdk")
+  ) {
+    [controlIp, controlType] = settings.control.deviceId.split("|");
+    if (!isRDKConnected) {
+      const cfg = findRDKDeviceConfig(settings.control.deviceId);
+      if (cfg) {
+        isRDKConnected = connectRDK(cfg.host, cfg.port, cfg.token);
+      }
+    }
+  }
+
   if (settings.display?.shortcut) {
     registerShortcut(settings.display.shortcut, displayWindow);
   }
@@ -540,6 +562,19 @@ app.whenReady().then(async () => {
     updateShowDisplayMenuItem(true);
   });
 
+  function findRDKDeviceConfig(deviceId) {
+    if (typeof deviceId !== "string" || !deviceId.endsWith("|rdk")) return null;
+    const device = (settings.control.deviceList || []).find((d) => d.id === deviceId);
+    if (!device) {
+      const [hostPort] = deviceId.split("|");
+      const [host, portStr] = hostPort.split(":");
+      const port = parseInt(portStr, 10);
+      if (!host || Number.isNaN(port)) return null;
+      return { host, port, token: "" };
+    }
+    return { host: device.ipAddress, port: device.port, token: device.token || "" };
+  }
+
   function switchControlDevice(deviceId) {
     if (!deviceId) return;
     settings.control.deviceId = deviceId;
@@ -561,8 +596,17 @@ app.whenReady().then(async () => {
     if (isADBConnected && oldControlIp !== controlIp) {
       isADBConnected = disconnectADB();
     }
+    if (isRDKConnected && oldControlIp !== controlIp) {
+      isRDKConnected = disconnectRDK();
+    }
     if (!isADBConnected && controlType === "adb") {
       isADBConnected = connectADB(controlIp, settings.control?.adbPath);
+    }
+    if (!isRDKConnected && controlType === "rdk") {
+      const cfg = findRDKDeviceConfig(deviceId);
+      if (cfg) {
+        isRDKConnected = connectRDK(cfg.host, cfg.port, cfg.token);
+      }
     }
     displayWindow?.webContents?.send("shared-window-channel", {
       type: "set-control-selected",
@@ -732,6 +776,9 @@ app.whenReady().then(async () => {
         if (isATVConnected) {
           isATVConnected = disconnectATV();
         }
+        if (isRDKConnected) {
+          isRDKConnected = disconnectRDK();
+        }
       }
       settings.control.deviceList = arg.payload;
       // If current device was removed and display window is hidden, show it
@@ -748,11 +795,20 @@ app.whenReady().then(async () => {
       if (isATVConnected && oldControlIp !== controlIp) {
         isATVConnected = disconnectATV();
       }
+      if (isRDKConnected && oldControlIp !== controlIp) {
+        isRDKConnected = disconnectRDK();
+      }
       if (!isADBConnected && controlType === "adb") {
         isADBConnected = connectADB(controlIp, settings.control?.adbPath);
       }
       if (!isATVConnected && controlType === "atv") {
         isATVConnected = connectATV(controlIp, settings.control?.atvremotePath);
+      }
+      if (!isRDKConnected && controlType === "rdk") {
+        const cfg = findRDKDeviceConfig(arg.payload);
+        if (cfg) {
+          isRDKConnected = connectRDK(cfg.host, cfg.port, cfg.token);
+        }
       }
     } else if (arg.type && arg.type === "send-adb-key") {
       sendADBKey(arg.payload);
@@ -762,6 +818,10 @@ app.whenReady().then(async () => {
       sendATVKey(arg.payload);
     } else if (arg.type && arg.type === "send-atv-text") {
       sendATVText(arg.payload);
+    } else if (arg.type && arg.type === "send-rdk-key") {
+      sendRDKKey(arg.payload);
+    } else if (arg.type && arg.type === "send-rdk-text") {
+      sendRDKText(arg.payload);
     } else if (arg.type && arg.type === "set-adb-path") {
       settings.control.adbPath = arg.payload;
       saveFlag = true;
@@ -966,6 +1026,19 @@ app.whenReady().then(async () => {
       const adbPath = result.filePaths[0];
       settings.control.adbPath = adbPath;
       return adbPath;
+    }
+  });
+
+  ipcMain.handle("test-rdk-connection", async (event, { host, port, token } = {}) => {
+    return testRDKConnection({ host, port, token });
+  });
+
+  ipcMain.handle("launch-rdk-app", async (event, { client, uri } = {}) => {
+    try {
+      const result = await launchRDKApp(client, uri);
+      return { success: true, result };
+    } catch (err) {
+      return { success: false, error: err.message };
     }
   });
 
@@ -1280,6 +1353,7 @@ app.whenReady().then(async () => {
       let connected = false;
       if (type === "adb") connected = isADBConnected;
       else if (type === "atv") connected = isATVConnected;
+      else if (type === "rdk") connected = isRDKConnected;
       else if (type === "ecp") connected = !!ip;
       return { id, ip, type, connected };
     },
@@ -1303,6 +1377,16 @@ app.whenReady().then(async () => {
         isATVConnected = connectATV(controlIp, settings.control?.atvremotePath);
       }
       return mcpCtx.getCurrentDevice();
+    },
+    launchApp: async ({ client, uri } = {}) => {
+      if (controlType !== "rdk") {
+        throw new Error("launch_app is only supported on RDK (Xumo) devices.");
+      }
+      if (!client) {
+        throw new Error("client is required.");
+      }
+      const result = await launchRDKApp(client, uri);
+      return { launched: client, uri: uri || null, result };
     },
     sendKey: async (nativeKey, mod) => {
       if (!settings.control.deviceId) {
@@ -1498,6 +1582,12 @@ app.whenReady().then(async () => {
     }
     if (isADBConnected) {
       disconnectADB();
+    }
+    if (isATVConnected) {
+      disconnectATV();
+    }
+    if (isRDKConnected) {
+      disconnectRDK();
     }
     if (isScriptRecording) {
       displayWindow?.webContents.send("discard-script-recording");

--- a/public/mcp-tools.js
+++ b/public/mcp-tools.js
@@ -24,24 +24,24 @@ const { z } = require("zod");
  * Roku ECP command such as "search") which is forwarded as-is.
  */
 const SEMANTIC_KEYS = {
-  up: { ecp: "up", adb: "19", atv: "up" },
-  down: { ecp: "down", adb: "20", atv: "down" },
-  left: { ecp: "left", adb: "21", atv: "left" },
-  right: { ecp: "right", adb: "22", atv: "right" },
-  select: { ecp: "select", adb: "66", atv: "select" },
-  ok: { ecp: "select", adb: "66", atv: "select" },
-  back: { ecp: "back", adb: "4", atv: "menu" },
-  home: { ecp: "home", adb: "3", atv: "home" },
-  play: { ecp: "play", adb: "85", atv: "play_pause" },
-  pause: { ecp: "play", adb: "85", atv: "play_pause" },
-  rewind: { ecp: "rev", adb: "89", atv: "previous" },
-  forward: { ecp: "fwd", adb: "90", atv: "next" },
-  replay: { ecp: "instantreplay", adb: null, atv: null },
-  info: { ecp: "info", adb: null, atv: "top_menu" },
-  options: { ecp: "info", adb: null, atv: "top_menu" },
-  volume_mute: { ecp: "volumemute", adb: "164", atv: null },
-  volume_up: { ecp: null, adb: "24", atv: "volume_up" },
-  volume_down: { ecp: null, adb: "25", atv: "volume_down" },
+  up: { ecp: "up", adb: "19", atv: "up", rdk: "103" },
+  down: { ecp: "down", adb: "20", atv: "down", rdk: "108" },
+  left: { ecp: "left", adb: "21", atv: "left", rdk: "105" },
+  right: { ecp: "right", adb: "22", atv: "right", rdk: "106" },
+  select: { ecp: "select", adb: "66", atv: "select", rdk: "28" },
+  ok: { ecp: "select", adb: "66", atv: "select", rdk: "28" },
+  back: { ecp: "back", adb: "4", atv: "menu", rdk: "158" },
+  home: { ecp: "home", adb: "3", atv: "home", rdk: "102" },
+  play: { ecp: "play", adb: "85", atv: "play_pause", rdk: "164" },
+  pause: { ecp: "play", adb: "85", atv: "play_pause", rdk: "164" },
+  rewind: { ecp: "rev", adb: "89", atv: "previous", rdk: "168" },
+  forward: { ecp: "fwd", adb: "90", atv: "next", rdk: "208" },
+  replay: { ecp: "instantreplay", adb: null, atv: null, rdk: null },
+  info: { ecp: "info", adb: null, atv: "top_menu", rdk: "139" },
+  options: { ecp: "info", adb: null, atv: "top_menu", rdk: "139" },
+  volume_mute: { ecp: "volumemute", adb: "164", atv: null, rdk: "113" },
+  volume_up: { ecp: null, adb: "24", atv: "volume_up", rdk: "115" },
+  volume_down: { ecp: null, adb: "25", atv: "volume_down", rdk: "114" },
 };
 
 const SEMANTIC_KEY_NAMES = Object.keys(SEMANTIC_KEYS);
@@ -113,7 +113,7 @@ function registerDeviceTools(server, ctx) {
     {
       title: "List control devices",
       description:
-        "Return all configured control devices with their protocol (ecp/adb/atv) and connection status.",
+        "Return all configured control devices with their protocol (ecp/adb/atv/rdk) and connection status.",
     },
     handler(async () => textResult(ctx.listDevices()))
   );
@@ -123,7 +123,7 @@ function registerDeviceTools(server, ctx) {
     {
       title: "Select control device",
       description:
-        "Switch the active control device by its id (formats: '<ip>|ecp', '<ip>|adb', '<uuid-or-mac>|atv').",
+        "Switch the active control device by its id (formats: '<ip>|ecp', '<ip>|adb', '<uuid-or-mac>|atv', '<host:port>|rdk').",
       inputSchema: {
         deviceId: z.string().describe("Device id in '<address>|<protocol>' form."),
       },
@@ -173,6 +173,20 @@ function registerDeviceTools(server, ctx) {
       await ctx.sendText(text);
       return textResult({ sent: text });
     })
+  );
+
+  server.registerTool(
+    "launch_app",
+    {
+      title: "Launch app",
+      description:
+        "Launch an application on the current device. RDK (Xumo) only — uses RDKShell.launchApplication.",
+      inputSchema: {
+        client: z.string().describe("Application client name (e.g. 'Netflix', 'Cobalt', 'HtmlApp')."),
+        uri: z.string().optional().describe("Optional URI/deep-link payload to pass to the app."),
+      },
+    },
+    handler(async ({ client, uri }) => textResult(await ctx.launchApp({ client, uri })))
   );
 }
 
@@ -294,7 +308,7 @@ function registerScriptTools(server, ctx) {
         "(-1 keypress/keydown, 0 keypress, 100 keyup), and a delay in ms before the step.",
       inputSchema: {
         name: z.string().optional().describe("Optional script name."),
-        controlType: z.enum(["ecp", "adb", "atv"]).describe("Target protocol for the steps."),
+        controlType: z.enum(["ecp", "adb", "atv", "rdk"]).describe("Target protocol for the steps."),
         steps: z
           .array(
             z.object({

--- a/public/rdk.js
+++ b/public/rdk.js
@@ -1,0 +1,231 @@
+/*---------------------------------------------------------------------------------------------
+ *  Carabiner - Simple Screen Capture and Remote Control App for Streaming Devices
+ *
+ *  Repository: https://github.com/lvcabral/carabiner
+ *
+ *  Copyright (c) 2024-2026 Marcelo Lv Cabral. All Rights Reserved.
+ *
+ *  Licensed under the MIT License. See LICENSE in the repository root for license information.
+ *--------------------------------------------------------------------------------------------*/
+const http = require("http");
+
+let host = "";
+let port = 9998;
+let token = "";
+let isRDKConnected = false;
+let rpcSeq = 0;
+
+function jsonRpc(method, params = {}, options = {}) {
+  const targetHost = options.host ?? host;
+  const targetPort = options.port ?? port;
+  const targetToken = options.token ?? token;
+  const timeoutMs = options.timeoutMs ?? 5000;
+  if (!targetHost) {
+    return Promise.reject(new Error("RDK host is not configured."));
+  }
+  return new Promise((resolve, reject) => {
+    const body = JSON.stringify({
+      jsonrpc: "2.0",
+      id: ++rpcSeq,
+      method,
+      params,
+    });
+    const headers = {
+      "Content-Type": "application/json",
+      "Content-Length": Buffer.byteLength(body),
+    };
+    if (targetToken) {
+      headers["Authorization"] = `Bearer ${targetToken}`;
+    }
+    const req = http.request(
+      {
+        host: targetHost,
+        port: targetPort,
+        path: "/jsonrpc",
+        method: "POST",
+        headers,
+        timeout: timeoutMs,
+      },
+      (res) => {
+        let data = "";
+        res.setEncoding("utf8");
+        res.on("data", (chunk) => (data += chunk));
+        res.on("end", () => {
+          if (res.statusCode < 200 || res.statusCode >= 300) {
+            reject(new Error(`HTTP ${res.statusCode}: ${data || res.statusMessage}`));
+            return;
+          }
+          try {
+            const parsed = data ? JSON.parse(data) : {};
+            if (parsed.error) {
+              reject(new Error(parsed.error.message || JSON.stringify(parsed.error)));
+              return;
+            }
+            resolve(parsed.result);
+          } catch (err) {
+            reject(new Error(`Invalid JSON-RPC response: ${err.message}`));
+          }
+        });
+      }
+    );
+    req.on("timeout", () => {
+      req.destroy(new Error(`Timed out after ${timeoutMs}ms`));
+    });
+    req.on("error", (err) => reject(err));
+    req.write(body);
+    req.end();
+  });
+}
+
+function connectRDK(rdkHost, rdkPort, rdkToken) {
+  if (typeof rdkHost !== "string" || rdkHost === "") {
+    console.error("RDK host not provided.");
+    return false;
+  }
+  host = rdkHost;
+  port = Number(rdkPort) || 9998;
+  token = typeof rdkToken === "string" ? rdkToken : "";
+  isRDKConnected = true;
+  console.log(`RDK configured for ${host}:${port}`);
+  jsonRpc("Controller.1.status").catch((err) => {
+    console.warn(`RDK reachability check failed for ${host}:${port}: ${err.message}`);
+  });
+  return isRDKConnected;
+}
+
+function disconnectRDK() {
+  host = "";
+  port = 9998;
+  token = "";
+  isRDKConnected = false;
+  console.log("Disconnected from RDK");
+  return isRDKConnected;
+}
+
+async function testRDKConnection({ host: testHost, port: testPort, token: testToken } = {}) {
+  try {
+    const result = await jsonRpc(
+      "Controller.1.status",
+      {},
+      { host: testHost, port: testPort, token: testToken, timeoutMs: 4000 }
+    );
+    return { success: true, result };
+  } catch (err) {
+    return { success: false, error: err.message };
+  }
+}
+
+function sendRDKKey(keyCode, modifiers = []) {
+  if (!isRDKConnected || !host) {
+    console.error("Cannot send RDK key — not connected.", { isRDKConnected, host });
+    return;
+  }
+  const code = parseInt(keyCode, 10);
+  if (Number.isNaN(code)) {
+    console.error(`Invalid RDK key code: ${keyCode}`);
+    return;
+  }
+  jsonRpc("org.rdk.RDKShell.1.injectKey", { keyCode: code, modifiers }).catch((err) => {
+    console.error(`RDK injectKey failed for ${code}: ${err.message}`);
+  });
+}
+
+async function sendRDKText(text) {
+  if (!isRDKConnected || typeof text !== "string" || text.length === 0) {
+    return;
+  }
+  for (const char of text) {
+    const mapping = textCharToInjectKey(char);
+    if (!mapping) continue;
+    try {
+      await jsonRpc("org.rdk.RDKShell.1.injectKey", {
+        keyCode: mapping.keyCode,
+        modifiers: mapping.modifiers,
+      });
+    } catch (err) {
+      console.error(`RDK text inject failed for '${char}': ${err.message}`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+}
+
+function launchRDKApp(client, uri) {
+  if (!isRDKConnected || !host) {
+    return Promise.reject(new Error("RDK is not connected."));
+  }
+  if (!client) {
+    return Promise.reject(new Error("client is required."));
+  }
+  const params = { client };
+  if (uri) params.uri = uri;
+  return jsonRpc("org.rdk.RDKShell.1.launchApplication", params);
+}
+
+// Linux input event code reference for the printable ASCII range.
+// Letters use code 30..56 (KEY_A..KEY_M, KEY_N..KEY_Z); digits 2..11 (KEY_1..KEY_0); space 57.
+function textCharToInjectKey(char) {
+  if (char === " ") return { keyCode: 57, modifiers: [] };
+  if (/^[a-z]$/.test(char)) {
+    return { keyCode: LETTER_CODES[char], modifiers: [] };
+  }
+  if (/^[A-Z]$/.test(char)) {
+    return { keyCode: LETTER_CODES[char.toLowerCase()], modifiers: ["shift"] };
+  }
+  if (/^[0-9]$/.test(char)) {
+    if (char === "0") return { keyCode: 11, modifiers: [] };
+    return { keyCode: 1 + parseInt(char, 10), modifiers: [] };
+  }
+  const punct = PUNCT_CODES[char];
+  if (punct) return punct;
+  return null;
+}
+
+const LETTER_CODES = {
+  a: 30, b: 48, c: 46, d: 32, e: 18, f: 33, g: 34, h: 35, i: 23, j: 36,
+  k: 37, l: 38, m: 50, n: 49, o: 24, p: 25, q: 16, r: 19, s: 31, t: 20,
+  u: 22, v: 47, w: 17, x: 45, y: 21, z: 44,
+};
+
+const PUNCT_CODES = {
+  "-": { keyCode: 12, modifiers: [] },
+  "_": { keyCode: 12, modifiers: ["shift"] },
+  "=": { keyCode: 13, modifiers: [] },
+  "+": { keyCode: 13, modifiers: ["shift"] },
+  "[": { keyCode: 26, modifiers: [] },
+  "{": { keyCode: 26, modifiers: ["shift"] },
+  "]": { keyCode: 27, modifiers: [] },
+  "}": { keyCode: 27, modifiers: ["shift"] },
+  "\\": { keyCode: 43, modifiers: [] },
+  "|": { keyCode: 43, modifiers: ["shift"] },
+  ";": { keyCode: 39, modifiers: [] },
+  ":": { keyCode: 39, modifiers: ["shift"] },
+  "'": { keyCode: 40, modifiers: [] },
+  "\"": { keyCode: 40, modifiers: ["shift"] },
+  ",": { keyCode: 51, modifiers: [] },
+  "<": { keyCode: 51, modifiers: ["shift"] },
+  ".": { keyCode: 52, modifiers: [] },
+  ">": { keyCode: 52, modifiers: ["shift"] },
+  "/": { keyCode: 53, modifiers: [] },
+  "?": { keyCode: 53, modifiers: ["shift"] },
+  "`": { keyCode: 41, modifiers: [] },
+  "~": { keyCode: 41, modifiers: ["shift"] },
+  "!": { keyCode: 2, modifiers: ["shift"] },
+  "@": { keyCode: 3, modifiers: ["shift"] },
+  "#": { keyCode: 4, modifiers: ["shift"] },
+  "$": { keyCode: 5, modifiers: ["shift"] },
+  "%": { keyCode: 6, modifiers: ["shift"] },
+  "^": { keyCode: 7, modifiers: ["shift"] },
+  "&": { keyCode: 8, modifiers: ["shift"] },
+  "*": { keyCode: 9, modifiers: ["shift"] },
+  "(": { keyCode: 10, modifiers: ["shift"] },
+  ")": { keyCode: 11, modifiers: ["shift"] },
+};
+
+module.exports = {
+  connectRDK,
+  disconnectRDK,
+  testRDKConnection,
+  sendRDKKey,
+  sendRDKText,
+  launchRDKApp,
+};

--- a/public/render.js
+++ b/public/render.js
@@ -116,12 +116,25 @@ const ATV_DISPLAY_NAMES = {
   top_menu: "Top Menu", previous: "Prev", next: "Next",
 };
 
+// RDK keycodes are Linux input event codes (numeric).
+const RDK_DISPLAY_NAMES = {
+  "103": "Up", "108": "Down", "105": "Left", "106": "Right",
+  "28": "OK", "158": "Back", "102": "Home",
+  "164": "Play/Pause", "119": "Pause", "168": "Rev", "208": "Fwd",
+  "115": "Vol+", "114": "Vol-", "113": "Mute",
+  "139": "Menu", "14": "⌫",
+};
+
 function formatDeviceKeyLabel(key, type) {
   if (type === "ecp") {
     return ECP_DISPLAY_NAMES[key.toLowerCase()] || key.charAt(0).toUpperCase() + key.slice(1);
   }
   if (type === "atv") {
     return ATV_DISPLAY_NAMES[key] || key.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+  }
+  if (type === "rdk") {
+    if (RDK_DISPLAY_NAMES[key]) return RDK_DISPLAY_NAMES[key];
+    return String(key);
   }
   // ADB: numeric keycodes → readable name
   if (ADB_DISPLAY_NAMES[key]) return ADB_DISPLAY_NAMES[key];
@@ -817,6 +830,18 @@ window.addEventListener("DOMContentLoaded", function () {
         recordScriptStep(litKey, -1);
         sendKey(litKey, -1);
       }
+    } else if (controlType === "rdk") {
+      const key = rdkKeysMap.get(keyCode);
+      if (key && mod === 0) {
+        if (showKeystrokes) displayKeyIndicator(formatDeviceKeyLabel(key, "rdk"));
+        recordScriptStep(key, mod);
+        sendKey(key, mod);
+      } else if (event.key.length === 1 && mod === 0) {
+        if (showKeystrokes) displayKeyIndicator(event.key.toUpperCase());
+        const litKey = `lit_${encodeURIComponent(event.key)}`;
+        recordScriptStep(litKey, -1);
+        sendKey(litKey, -1);
+      }
     }
   }
 
@@ -1489,6 +1514,37 @@ if (isMacOS) {
   atvKeysMap.set("Control+ArrowRight", "next");
 }
 
+// RDK / Xumo Keyboard Mapping (Linux input event codes; sent via RDKShell.injectKey)
+const rdkKeysMap = new Map();
+rdkKeysMap.set("ArrowUp", "103");
+rdkKeysMap.set("ArrowDown", "108");
+rdkKeysMap.set("ArrowLeft", "105");
+rdkKeysMap.set("ArrowRight", "106");
+rdkKeysMap.set("Enter", "28");
+rdkKeysMap.set("Escape", "158");
+rdkKeysMap.set("Delete", "158");
+rdkKeysMap.set("Home", "102");
+rdkKeysMap.set("Shift+Escape", "102");
+rdkKeysMap.set("Control+Escape", "102");
+rdkKeysMap.set("Backspace", "14");
+rdkKeysMap.set("End", "164");
+rdkKeysMap.set("PageUp", "168");
+rdkKeysMap.set("PageDown", "208");
+rdkKeysMap.set("Insert", "139");
+rdkKeysMap.set("F10", "113");
+if (isMacOS) {
+  rdkKeysMap.set("Command+Enter", "164");
+  rdkKeysMap.set("Command+ArrowLeft", "168");
+  rdkKeysMap.set("Command+ArrowRight", "208");
+} else {
+  rdkKeysMap.set("Control+Enter", "164");
+  rdkKeysMap.set("Control+ArrowLeft", "168");
+  rdkKeysMap.set("Control+ArrowRight", "208");
+}
+for (let i = 0; i <= 9; i++) {
+  rdkKeysMap.set(`Digit${i}`, i === 0 ? "11" : String(1 + i));
+}
+
 // Type text character by character with proper timing
 async function typeText(text) {
   // Clean the text by replacing special characters with spaces
@@ -1522,6 +1578,12 @@ async function typeText(text) {
         await new Promise((resolve) => setTimeout(resolve, 50));
       }
     }
+  } else if (controlType === "rdk") {
+    // For RDK, the main process types char-by-char via RDKShell.injectKey.
+    window.electronAPI.sendSync("shared-window-channel", {
+      type: "send-rdk-text",
+      payload: cleanText,
+    });
   }
 }
 
@@ -1588,6 +1650,18 @@ function sendKey(key, mod) {
     } else if (mod === 0) {
       window.electronAPI.sendSync("shared-window-channel", {
         type: "send-atv-key",
+        payload: key,
+      });
+    }
+  } else if (controlIp && controlType === "rdk") {
+    if (key.startsWith("lit_") && mod === -1) {
+      window.electronAPI.sendSync("shared-window-channel", {
+        type: "send-rdk-text",
+        payload: decodeURIComponent(key.slice(4)),
+      });
+    } else if (mod === 0) {
+      window.electronAPI.sendSync("shared-window-channel", {
+        type: "send-rdk-key",
         payload: key,
       });
     }

--- a/src/components/ControlSection.js
+++ b/src/components/ControlSection.js
@@ -24,6 +24,9 @@ function ControlSection({ streamingDevices, onUpdateStreamingDevices, onDeletedD
   const [selectedDevice, setSelectedDevice] = useState("");
   const [adbPath, setAdbPath] = useState("");
   const [atvremotePath, setAtvremotePath] = useState("");
+  const [rdkPort, setRdkPort] = useState("9998");
+  const [rdkToken, setRdkToken] = useState("");
+  const [rdkTestStatus, setRdkTestStatus] = useState("");
   const [repoUrl, setRepoUrl] = useState("");
   const [errorMessage, setErrorMessage] = useState("");
   const ipAddressRef = useRef(null);
@@ -54,16 +57,37 @@ function ControlSection({ streamingDevices, onUpdateStreamingDevices, onDeletedD
     return uuidRegex.test(id) || macRegex.test(id) || isValidIpAddress(id);
   };
 
+  const isValidPort = (value) => {
+    const n = Number(value);
+    return Number.isInteger(n) && n > 0 && n <= 65535;
+  };
+
   const handleAddDevice = () => {
     const isAppleTV = deviceType === "appletv";
-    if (isAppleTV ? !isValidAtvDeviceId(ipAddress) : !isValidIpAddress(ipAddress)) {
-      setErrorMessage(isAppleTV ? "Invalid device ID (use UUID, MAC address, or IP)." : "Invalid IP address format.");
+    const isRDK = deviceType === "xumo";
+    if (isAppleTV) {
+      if (!isValidAtvDeviceId(ipAddress)) {
+        setErrorMessage("Invalid device ID (use UUID, MAC address, or IP).");
+        setTimeout(() => setErrorMessage(""), 3000);
+        return;
+      }
+    } else if (!isValidIpAddress(ipAddress)) {
+      setErrorMessage("Invalid IP address format.");
+      setTimeout(() => setErrorMessage(""), 3000);
+      return;
+    }
+    if (isRDK && !isValidPort(rdkPort)) {
+      setErrorMessage("Invalid RDK port (must be 1–65535).");
       setTimeout(() => setErrorMessage(""), 3000);
       return;
     }
 
-    if (streamingDevices.some((device) => device.ipAddress === ipAddress)) {
-      setErrorMessage(isAppleTV ? "Device ID already exists." : "IP address already exists.");
+    const proposedId = isRDK ? `${ipAddress}:${rdkPort}|rdk` : null;
+    const dupCheck = isRDK
+      ? streamingDevices.some((device) => device.id === proposedId)
+      : streamingDevices.some((device) => device.ipAddress === ipAddress);
+    if (dupCheck) {
+      setErrorMessage(isAppleTV ? "Device ID already exists." : "Device already exists.");
       setTimeout(() => setErrorMessage(""), 3000);
       return;
     }
@@ -74,6 +98,8 @@ function ControlSection({ streamingDevices, onUpdateStreamingDevices, onDeletedD
         protocol = "adb";
       } else if (deviceType === "appletv") {
         protocol = "atv";
+      } else if (deviceType === "xumo") {
+        protocol = "rdk";
       }
       let type = "";
       if (deviceType === "roku") {
@@ -84,21 +110,51 @@ function ControlSection({ streamingDevices, onUpdateStreamingDevices, onDeletedD
         type = "Google TV";
       } else if (deviceType === "appletv") {
         type = "Apple TV";
+      } else if (deviceType === "xumo") {
+        type = "Xumo Stream Box";
       }
       const newDevice = {
-        id: `${ipAddress}|${protocol}`,
+        id: isRDK ? proposedId : `${ipAddress}|${protocol}`,
         ipAddress: ipAddress,
         alias: alias.trim(),
         linked: "",
         type: type,
       };
+      if (isRDK) {
+        newDevice.port = Number(rdkPort);
+        newDevice.token = rdkToken.trim();
+      }
       const newDeviceList = [...streamingDevices, newDevice];
       onUpdateStreamingDevices(newDeviceList);
       setIpAddress("");
       setAlias("");
+      setRdkToken("");
+      setRdkTestStatus("");
       setSelectedDevice(newDevice.id);
       setErrorMessage("");
       ipAddressRef.current.focus();
+    }
+  };
+
+  const handleTestRdkConnection = async () => {
+    if (!isValidIpAddress(ipAddress)) {
+      setRdkTestStatus("Invalid IP address.");
+      return;
+    }
+    if (!isValidPort(rdkPort)) {
+      setRdkTestStatus("Invalid port.");
+      return;
+    }
+    setRdkTestStatus("Testing…");
+    const result = await electronAPI.invoke("test-rdk-connection", {
+      host: ipAddress,
+      port: Number(rdkPort),
+      token: rdkToken.trim(),
+    });
+    if (result?.success) {
+      setRdkTestStatus("Connected ✓");
+    } else {
+      setRdkTestStatus(`Failed: ${result?.error || "no response"}`);
     }
   };
 
@@ -206,8 +262,52 @@ function ControlSection({ streamingDevices, onUpdateStreamingDevices, onDeletedD
                     disabled={!atvremotePath}
                   />
                 </Col>
+                <Col xs="auto" className="d-flex align-items-center">
+                  <Form.Check
+                    type="radio"
+                    label="Xumo (RDK)"
+                    name="deviceType"
+                    value="xumo"
+                    checked={deviceType === "xumo"}
+                    onChange={(e) => setDeviceType(e.target.value)}
+                  />
+                </Col>
               </Row>
             </Form.Group>
+            {deviceType === "xumo" && (
+              <Form.Group controlId="formRdkConfig" className="form-group-spacing">
+                <Row className="align-items-center">
+                  <Col xs={3}>
+                    <Form.Control
+                      size="sm"
+                      type="text"
+                      placeholder="Port"
+                      value={rdkPort}
+                      onChange={(e) => setRdkPort(e.target.value)}
+                    />
+                  </Col>
+                  <Col>
+                    <Form.Control
+                      size="sm"
+                      type="text"
+                      placeholder="Bearer token (optional)"
+                      value={rdkToken}
+                      onChange={(e) => setRdkToken(e.target.value)}
+                    />
+                  </Col>
+                  <Col xs="auto">
+                    <Button size="sm" variant="outline-secondary" onClick={handleTestRdkConnection}>
+                      Test
+                    </Button>
+                  </Col>
+                </Row>
+                {rdkTestStatus && (
+                  <div style={{ fontSize: "0.72rem", marginTop: "4px", color: rdkTestStatus.startsWith("Connected") ? "#198754" : "#b61717" }}>
+                    {rdkTestStatus}
+                  </div>
+                )}
+              </Form.Group>
+            )}
             <Form.Group controlId="formDeviceList" className="form-group-spacing">
               {errorMessage && (
                 <Alert
@@ -236,6 +336,7 @@ function ControlSection({ streamingDevices, onUpdateStreamingDevices, onDeletedD
                       <option key={index} value={device.id}>
                         {device.type}: {device.alias ? device.alias + " - " : ""}
                         {device.ipAddress}
+                        {device.port ? `:${device.port}` : ""}
                       </option>
                     ))}
                   </Form.Control>
@@ -247,74 +348,80 @@ function ControlSection({ streamingDevices, onUpdateStreamingDevices, onDeletedD
                 </Col>
               </Row>
             </Form.Group>
-            <Form.Group controlId="formAdbPath" className="form-group-spacing">
-              <Form.Label className="d-flex justify-content-between align-items-center w-100">
-                ADB Tool Path (Android based devices like Fire TV and Google TV)
-                <a
-                  href="#adb-setup"
-                  style={{ fontSize: "0.75rem" }}
-                  onClick={(e) => { e.preventDefault(); electronAPI.openExternal(`${repoUrl}/blob/main/docs/setup-android-firetv.md`); }}
-                >
-                  Setup Guide ↗
-                </a>
-              </Form.Label>
-              <Row>
-                <Col className="d-flex align-items-center flex-grow-1">
-                  <Form.Control
-                    size="sm"
-                    type="text"
-                    value={adbPath}
-                    onChange={(e) => { setAdbPath(e.target.value); notifyControlChange("set-adb-path", e.target.value); }}
-                    placeholder="Paste or select path to adb binary"
-                  />
-                </Col>
-                <Col xs="auto" className="d-flex align-items-center">
-                  <Button size="sm" title="Select ADB Path" variant="primary" onClick={handleSelectAdbPath}>
-                    &#x2026;
-                  </Button>
-                </Col>
-              </Row>
-            </Form.Group>
-            <Form.Group controlId="formAtvremotePath" className="form-group-spacing">
-              <Form.Label className="d-flex justify-content-between align-items-center w-100">
-                atvremote Tool Path (Apple TV devices)
-                <a
-                  href="#atv-setup"
-                  style={{ fontSize: "0.75rem" }}
-                  onClick={(e) => { e.preventDefault(); electronAPI.openExternal(`${repoUrl}/blob/main/docs/setup-apple-tv.md`); }}
-                >
-                  Setup Guide ↗
-                </a>
-              </Form.Label>
-              <Row>
-                <Col className="d-flex align-items-center flex-grow-1">
-                  <Form.Control
-                    size="sm"
-                    type="text"
-                    value={atvremotePath}
-                    onChange={(e) => { setAtvremotePath(e.target.value); notifyControlChange("set-atv-path", e.target.value); }}
-                    placeholder="Paste or select path to atvremote binary"
-                  />
-                </Col>
-                <Col xs="auto" className="d-flex align-items-center">
-                  <Button size="sm" title="Select atvremote Path" variant="primary" onClick={handleSelectAtvPath}>
-                    &#x2026;
-                  </Button>
-                </Col>
-              </Row>
-            </Form.Group>
+            {deviceType !== "xumo" && (
+              <Form.Group controlId="formAdbPath" className="form-group-spacing">
+                <Form.Label className="d-flex justify-content-between align-items-center w-100">
+                  ADB Tool Path (Android based devices like Fire TV and Google TV)
+                  <a
+                    href="#adb-setup"
+                    style={{ fontSize: "0.75rem" }}
+                    onClick={(e) => { e.preventDefault(); electronAPI.openExternal(`${repoUrl}/blob/main/docs/setup-android-firetv.md`); }}
+                  >
+                    Setup Guide ↗
+                  </a>
+                </Form.Label>
+                <Row>
+                  <Col className="d-flex align-items-center flex-grow-1">
+                    <Form.Control
+                      size="sm"
+                      type="text"
+                      value={adbPath}
+                      onChange={(e) => { setAdbPath(e.target.value); notifyControlChange("set-adb-path", e.target.value); }}
+                      placeholder="Paste or select path to adb binary"
+                    />
+                  </Col>
+                  <Col xs="auto" className="d-flex align-items-center">
+                    <Button size="sm" title="Select ADB Path" variant="primary" onClick={handleSelectAdbPath}>
+                      &#x2026;
+                    </Button>
+                  </Col>
+                </Row>
+              </Form.Group>
+            )}
+            {deviceType !== "xumo" && (
+              <Form.Group controlId="formAtvremotePath" className="form-group-spacing">
+                <Form.Label className="d-flex justify-content-between align-items-center w-100">
+                  atvremote Tool Path (Apple TV devices)
+                  <a
+                    href="#atv-setup"
+                    style={{ fontSize: "0.75rem" }}
+                    onClick={(e) => { e.preventDefault(); electronAPI.openExternal(`${repoUrl}/blob/main/docs/setup-apple-tv.md`); }}
+                  >
+                    Setup Guide ↗
+                  </a>
+                </Form.Label>
+                <Row>
+                  <Col className="d-flex align-items-center flex-grow-1">
+                    <Form.Control
+                      size="sm"
+                      type="text"
+                      value={atvremotePath}
+                      onChange={(e) => { setAtvremotePath(e.target.value); notifyControlChange("set-atv-path", e.target.value); }}
+                      placeholder="Paste or select path to atvremote binary"
+                    />
+                  </Col>
+                  <Col xs="auto" className="d-flex align-items-center">
+                    <Button size="sm" title="Select atvremote Path" variant="primary" onClick={handleSelectAtvPath}>
+                      &#x2026;
+                    </Button>
+                  </Col>
+                </Row>
+              </Form.Group>
+            )}
           </Form>
         </Card.Body>
       </Card>
 
-      <Alert variant="warning" className="mt-2 mb-0 p-1" style={{ fontSize: "0.72rem" }}>
-        <strong>Roku users:</strong> To enable ECP (External Control Protocol), follow these steps on your device:
-        <ol className="mb-0 mt-1 ps-3">
-          <li>Go to <strong>Settings &gt; System &gt; Advanced system settings</strong>.</li>
-          <li>Select <strong>Control by mobile apps</strong>.</li>
-          <li>Set to <strong>Enabled</strong> or <strong>Permissive</strong>.</li>
-        </ol>
-      </Alert>
+      {deviceType !== "xumo" && (
+        <Alert variant="warning" className="mt-2 mb-0 p-1" style={{ fontSize: "0.72rem" }}>
+          <strong>Roku users:</strong> To enable ECP (External Control Protocol), follow these steps on your device:
+          <ol className="mb-0 mt-1 ps-3">
+            <li>Go to <strong>Settings &gt; System &gt; Advanced system settings</strong>.</li>
+            <li>Select <strong>Control by mobile apps</strong>.</li>
+            <li>Set to <strong>Enabled</strong> or <strong>Permissive</strong>.</li>
+          </ol>
+        </Alert>
+      )}
 
     </div>
   );

--- a/src/components/ControlSection.js
+++ b/src/components/ControlSection.js
@@ -62,23 +62,36 @@ function ControlSection({ streamingDevices, onUpdateStreamingDevices, onDeletedD
     return Number.isInteger(n) && n > 0 && n <= 65535;
   };
 
+  const showError = (msg) => {
+    setErrorMessage(msg);
+    setTimeout(() => setErrorMessage(""), 3000);
+  };
+
   const handleAddDevice = () => {
-    const isAppleTV = deviceType === "appletv";
+    const isAppleTVLocal = deviceType === "appletv";
     const isRDK = deviceType === "xumo";
-    if (isAppleTV) {
+    const isAdb = deviceType === "firetv" || deviceType === "googletv";
+
+    if (isAdb && !adbPath) {
+      showError("Set the ADB tool path below before adding this device.");
+      return;
+    }
+    if (isAppleTVLocal && !atvremotePath) {
+      showError("Set the atvremote tool path below before adding this device.");
+      return;
+    }
+
+    if (isAppleTVLocal) {
       if (!isValidAtvDeviceId(ipAddress)) {
-        setErrorMessage("Invalid device ID (use UUID, MAC address, or IP).");
-        setTimeout(() => setErrorMessage(""), 3000);
+        showError("Invalid device ID (use UUID, MAC address, or IP).");
         return;
       }
     } else if (!isValidIpAddress(ipAddress)) {
-      setErrorMessage("Invalid IP address format.");
-      setTimeout(() => setErrorMessage(""), 3000);
+      showError("Invalid IP address format.");
       return;
     }
     if (isRDK && !isValidPort(rdkPort)) {
-      setErrorMessage("Invalid RDK port (must be 1–65535).");
-      setTimeout(() => setErrorMessage(""), 3000);
+      showError("Invalid RDK port (must be 1–65535).");
       return;
     }
 
@@ -87,8 +100,7 @@ function ControlSection({ streamingDevices, onUpdateStreamingDevices, onDeletedD
       ? streamingDevices.some((device) => device.id === proposedId)
       : streamingDevices.some((device) => device.ipAddress === ipAddress);
     if (dupCheck) {
-      setErrorMessage(isAppleTV ? "Device ID already exists." : "Device already exists.");
-      setTimeout(() => setErrorMessage(""), 3000);
+      showError(isAppleTVLocal ? "Device ID already exists." : "Device already exists.");
       return;
     }
 
@@ -184,18 +196,40 @@ function ControlSection({ streamingDevices, onUpdateStreamingDevices, onDeletedD
     }
   };
 
+  const isAdbType = deviceType === "firetv" || deviceType === "googletv";
+  const isAppleTV = deviceType === "appletv";
+  const isXumo = deviceType === "xumo";
+
   return (
     <div className="p-2" style={{ position: "relative", fontSize: "0.85rem" }}>
       <Card>
         <Card.Body className="p-2">
           <Form>
+            <Form.Group controlId="formDeviceType" className="form-group-spacing">
+              <Form.Label>Select Device Type:</Form.Label>
+              <Form.Control
+                size="sm"
+                as="select"
+                value={deviceType}
+                onChange={(e) => {
+                  setDeviceType(e.target.value);
+                  setRdkTestStatus("");
+                }}
+              >
+                <option value="roku">Roku (ECP)</option>
+                <option value="firetv">Fire TV (ADB)</option>
+                <option value="googletv">Google TV (ADB)</option>
+                <option value="appletv">Apple TV (atvremote)</option>
+                <option value="xumo">Xumo (RDK)</option>
+              </Form.Control>
+            </Form.Group>
             <Form.Group controlId="formIpAddress" className="form-group-spacing">
               <Row className="align-items-center">
                 <Col>
                   <Form.Control
                     size="sm"
                     type="text"
-                    placeholder={deviceType === "appletv" ? "Enter Device ID (UUID or MAC)" : "Enter IP address"}
+                    placeholder={isAppleTV ? "Enter Device ID (UUID or MAC)" : "Enter IP address"}
                     value={ipAddress}
                     onChange={(e) => setIpAddress(e.target.value)}
                     ref={ipAddressRef}
@@ -217,65 +251,69 @@ function ControlSection({ streamingDevices, onUpdateStreamingDevices, onDeletedD
                 </Col>
               </Row>
             </Form.Group>
-            <Form.Group controlId="formDeviceType" className="form-group-spacing">
-              <Row>
-                <Col xs="auto" className="d-flex align-items-center">
-                  <Form.Check
-                    type="radio"
-                    label="Roku"
-                    name="deviceType"
-                    value="roku"
-                    checked={deviceType === "roku"}
-                    onChange={(e) => setDeviceType(e.target.value)}
-                  />
-                </Col>
-                <Col xs="auto" className="d-flex align-items-center">
-                  <Form.Check
-                    type="radio"
-                    label="Fire TV"
-                    name="deviceType"
-                    value="firetv"
-                    checked={deviceType === "firetv"}
-                    onChange={(e) => setDeviceType(e.target.value)}
-                    disabled={!adbPath}
-                  />
-                </Col>
-                <Col xs="auto" className="d-flex align-items-center">
-                  <Form.Check
-                    type="radio"
-                    label="Google TV"
-                    name="deviceType"
-                    value="googletv"
-                    checked={deviceType === "googletv"}
-                    onChange={(e) => setDeviceType(e.target.value)}
-                    disabled={!adbPath}
-                  />
-                </Col>
-                <Col xs="auto" className="d-flex align-items-center">
-                  <Form.Check
-                    type="radio"
-                    label="Apple TV"
-                    name="deviceType"
-                    value="appletv"
-                    checked={deviceType === "appletv"}
-                    onChange={(e) => setDeviceType(e.target.value)}
-                    disabled={!atvremotePath}
-                  />
-                </Col>
-                <Col xs="auto" className="d-flex align-items-center">
-                  <Form.Check
-                    type="radio"
-                    label="Xumo (RDK)"
-                    name="deviceType"
-                    value="xumo"
-                    checked={deviceType === "xumo"}
-                    onChange={(e) => setDeviceType(e.target.value)}
-                  />
-                </Col>
-              </Row>
-            </Form.Group>
-            {deviceType === "xumo" && (
+            {errorMessage && (
+              <Alert
+                variant="danger"
+                className="custom-alert"
+                style={{
+                  position: "absolute",
+                  top: "10px",
+                  left: "50%",
+                  transform: "translateX(-50%)",
+                  zIndex: 1050,
+                  minWidth: "300px",
+                  maxWidth: "90%",
+                  boxShadow: "0 4px 12px rgba(0,0,0,0.15)",
+                }}
+              >
+                {errorMessage}
+              </Alert>
+            )}
+            {isAdbType && (
+              <Form.Group controlId="formAdbPath" className="form-group-spacing">
+                <Form.Label>ADB Tool Path (Android based devices like Fire TV and Google TV)</Form.Label>
+                <Row>
+                  <Col className="d-flex align-items-center flex-grow-1">
+                    <Form.Control
+                      size="sm"
+                      type="text"
+                      value={adbPath}
+                      onChange={(e) => { setAdbPath(e.target.value); notifyControlChange("set-adb-path", e.target.value); }}
+                      placeholder="Paste or select path to adb binary"
+                    />
+                  </Col>
+                  <Col xs="auto" className="d-flex align-items-center">
+                    <Button size="sm" title="Select ADB Path" variant="primary" onClick={handleSelectAdbPath}>
+                      &#x2026;
+                    </Button>
+                  </Col>
+                </Row>
+              </Form.Group>
+            )}
+            {isAppleTV && (
+              <Form.Group controlId="formAtvremotePath" className="form-group-spacing">
+                <Form.Label>atvremote Tool Path (Apple TV devices)</Form.Label>
+                <Row>
+                  <Col className="d-flex align-items-center flex-grow-1">
+                    <Form.Control
+                      size="sm"
+                      type="text"
+                      value={atvremotePath}
+                      onChange={(e) => { setAtvremotePath(e.target.value); notifyControlChange("set-atv-path", e.target.value); }}
+                      placeholder="Paste or select path to atvremote binary"
+                    />
+                  </Col>
+                  <Col xs="auto" className="d-flex align-items-center">
+                    <Button size="sm" title="Select atvremote Path" variant="primary" onClick={handleSelectAtvPath}>
+                      &#x2026;
+                    </Button>
+                  </Col>
+                </Row>
+              </Form.Group>
+            )}
+            {isXumo && (
               <Form.Group controlId="formRdkConfig" className="form-group-spacing">
+                <Form.Label>RDK JSON-RPC Endpoint</Form.Label>
                 <Row className="align-items-center">
                   <Col xs={3}>
                     <Form.Control
@@ -309,24 +347,6 @@ function ControlSection({ streamingDevices, onUpdateStreamingDevices, onDeletedD
               </Form.Group>
             )}
             <Form.Group controlId="formDeviceList" className="form-group-spacing">
-              {errorMessage && (
-                <Alert
-                  variant="danger"
-                  className="custom-alert"
-                  style={{
-                    position: "absolute",
-                    top: "10px",
-                    left: "50%",
-                    transform: "translateX(-50%)",
-                    zIndex: 1050,
-                    minWidth: "300px",
-                    maxWidth: "90%",
-                    boxShadow: "0 4px 12px rgba(0,0,0,0.15)",
-                  }}
-                >
-                  {errorMessage}
-                </Alert>
-              )}
               <Form.Label>Streaming Device List</Form.Label>
               <Row>
                 <Col className="d-flex align-items-center flex-grow-1">
@@ -348,71 +368,11 @@ function ControlSection({ streamingDevices, onUpdateStreamingDevices, onDeletedD
                 </Col>
               </Row>
             </Form.Group>
-            {deviceType !== "xumo" && (
-              <Form.Group controlId="formAdbPath" className="form-group-spacing">
-                <Form.Label className="d-flex justify-content-between align-items-center w-100">
-                  ADB Tool Path (Android based devices like Fire TV and Google TV)
-                  <a
-                    href="#adb-setup"
-                    style={{ fontSize: "0.75rem" }}
-                    onClick={(e) => { e.preventDefault(); electronAPI.openExternal(`${repoUrl}/blob/main/docs/setup-android-firetv.md`); }}
-                  >
-                    Setup Guide ↗
-                  </a>
-                </Form.Label>
-                <Row>
-                  <Col className="d-flex align-items-center flex-grow-1">
-                    <Form.Control
-                      size="sm"
-                      type="text"
-                      value={adbPath}
-                      onChange={(e) => { setAdbPath(e.target.value); notifyControlChange("set-adb-path", e.target.value); }}
-                      placeholder="Paste or select path to adb binary"
-                    />
-                  </Col>
-                  <Col xs="auto" className="d-flex align-items-center">
-                    <Button size="sm" title="Select ADB Path" variant="primary" onClick={handleSelectAdbPath}>
-                      &#x2026;
-                    </Button>
-                  </Col>
-                </Row>
-              </Form.Group>
-            )}
-            {deviceType !== "xumo" && (
-              <Form.Group controlId="formAtvremotePath" className="form-group-spacing">
-                <Form.Label className="d-flex justify-content-between align-items-center w-100">
-                  atvremote Tool Path (Apple TV devices)
-                  <a
-                    href="#atv-setup"
-                    style={{ fontSize: "0.75rem" }}
-                    onClick={(e) => { e.preventDefault(); electronAPI.openExternal(`${repoUrl}/blob/main/docs/setup-apple-tv.md`); }}
-                  >
-                    Setup Guide ↗
-                  </a>
-                </Form.Label>
-                <Row>
-                  <Col className="d-flex align-items-center flex-grow-1">
-                    <Form.Control
-                      size="sm"
-                      type="text"
-                      value={atvremotePath}
-                      onChange={(e) => { setAtvremotePath(e.target.value); notifyControlChange("set-atv-path", e.target.value); }}
-                      placeholder="Paste or select path to atvremote binary"
-                    />
-                  </Col>
-                  <Col xs="auto" className="d-flex align-items-center">
-                    <Button size="sm" title="Select atvremote Path" variant="primary" onClick={handleSelectAtvPath}>
-                      &#x2026;
-                    </Button>
-                  </Col>
-                </Row>
-              </Form.Group>
-            )}
           </Form>
         </Card.Body>
       </Card>
 
-      {deviceType !== "xumo" && (
+      {deviceType === "roku" && (
         <Alert variant="warning" className="mt-2 mb-0 p-1" style={{ fontSize: "0.72rem" }}>
           <strong>Roku users:</strong> To enable ECP (External Control Protocol), follow these steps on your device:
           <ol className="mb-0 mt-1 ps-3">
@@ -420,6 +380,49 @@ function ControlSection({ streamingDevices, onUpdateStreamingDevices, onDeletedD
             <li>Select <strong>Control by mobile apps</strong>.</li>
             <li>Set to <strong>Enabled</strong> or <strong>Permissive</strong>.</li>
           </ol>
+        </Alert>
+      )}
+
+      {isAdbType && (
+        <Alert variant="warning" className="mt-2 mb-0 p-1" style={{ fontSize: "0.72rem" }}>
+          <strong>Fire TV / Google TV users:</strong> Enable Developer options and ADB debugging on the device:
+          <ol className="mb-0 mt-1 ps-3">
+            <li>Go to <strong>Settings &gt; My Fire TV / About</strong> (or the device's About screen).</li>
+            <li>Tap the build number 7 times to unlock <strong>Developer options</strong>.</li>
+            <li>Enable <strong>ADB debugging</strong> and <strong>Apps from Unknown Sources</strong>.</li>
+            <li>Install the <code>adb</code> binary on this machine and set its path above.</li>
+          </ol>
+          <a
+            href="#adb-setup"
+            onClick={(e) => { e.preventDefault(); electronAPI.openExternal(`${repoUrl}/blob/main/docs/setup-android-firetv.md`); }}
+          >
+            Setup Guide ↗
+          </a>
+        </Alert>
+      )}
+
+      {isAppleTV && (
+        <Alert variant="warning" className="mt-2 mb-0 p-1" style={{ fontSize: "0.72rem" }}>
+          <strong>Apple TV users:</strong> Requirements for `atvremote` (pyatv) control:
+          <ol className="mb-0 mt-1 ps-3">
+            <li>Install Python 3 and the <code>pyatv</code> package (provides the <code>atvremote</code> CLI).</li>
+            <li>Pair with the Apple TV using <code>atvremote pair --protocol companion</code> and save the credentials.</li>
+            <li>Enter the device's UUID, MAC address, or IP above and set the <code>atvremote</code> path.</li>
+          </ol>
+          <a
+            href="#atv-setup"
+            onClick={(e) => { e.preventDefault(); electronAPI.openExternal(`${repoUrl}/blob/main/docs/setup-apple-tv.md`); }}
+          >
+            Setup Guide ↗
+          </a>
+        </Alert>
+      )}
+
+      {isXumo && (
+        <Alert variant="warning" className="mt-2 mb-0 p-1" style={{ fontSize: "0.72rem" }}>
+          <strong>Xumo (Beta):</strong> RDK control is experimental. Retail Stream Boxes do not expose
+          the Thunder JSON-RPC port on the LAN — you need a developer-enabled device with port 9998
+          reachable from this machine. Reach out to Comcast/Xumo partner support for access.
         </Alert>
       )}
 


### PR DESCRIPTION
## Summary

- New `rdk` protocol backend in `public/rdk.js` that talks JSON-RPC over HTTP to RDK Services' Thunder framework. Sends keys via `org.rdk.RDKShell.1.injectKey` (Linux input event codes), supports text input as a sequence of injectKey calls, and exposes `launchApplication` for app deep-linking.
- Wires `rdk` into all the existing device-control branch points: `public/main.js` (startup connect, switch/disconnect lifecycle, IPC handlers, before-quit cleanup, MCP context), `public/render.js` (`rdkKeysMap`, keyboard handler, `sendKey`/`typeText`), and `public/mcp-tools.js` (`SEMANTIC_KEYS` rdk column, new `launch_app` tool).
- Reorganizes the Control tab in `src/components/ControlSection.js`: device type is now a single dropdown labeled `Roku (ECP)` / `Fire TV (ADB)` / `Google TV (ADB)` / `Apple TV (atvremote)` / `Xumo (RDK)`. The fields below switch per type — each protocol shows only its own tool-path or config row plus a setup-guide alert. Missing tool paths surface as a toast on the add action instead of disabling the button.

Device record format:
- Existing protocols unchanged: `<ip>|ecp`, `<ip>|adb`, `<uuid-or-mac>|atv`.
- New: `<host:port>|rdk`, with `port` and optional Bearer `token` stored on the device record.

## Background

Comcast's public Firebolt / EntertainmentOS docs are aimed at app publishers, not external automation, so there is no documented LAN remote-control API for retail Xumo / Sky Glass / X1 boxes. RDK Services' Thunder JSON-RPC endpoint (`127.0.0.1:9998` by default) is the real control surface but is firewalled off on consumer hardware — this backend targets developer / partner units where the Thunder port is reachable on the LAN. The Control tab's Xumo panel ships a Beta alert that calls this out.

## Test plan

- [ ] `npm run build` (already passes locally).
- [ ] On a dev-enabled Xumo Stream Box: `curl -X POST -d '{"jsonrpc":"2.0","id":1,"method":"Controller.1.status"}' http://<box>:9998/jsonrpc` returns a JSON response.
- [ ] Add the Stream Box from the Control tab → "Test" button reports green.
- [ ] Arrow keys / Enter / Escape in the floating display drive on-screen navigation.
- [ ] MCP `select_device`, `send_key {key:"home"}`, `launch_app {client:"Cobalt"}` work against the rdk device.
- [ ] Existing Roku / Fire TV / Google TV / Apple TV flows still work after the Control tab reorganization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)