### PR TITLE
Update documentation for Xumo Stream Box (RDK) support

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What This App Does
 
-Carabiner is an Electron desktop app for streaming device development and QA. It shows live video from a capture card (HDMI capture device) in a floating overlay window, while letting users control Roku devices via ECP (HTTP), Android/Fire TV/Google TV devices via ADB, or Apple TV via `atvremote` (pyatv). Primary users are developers testing streaming apps without a physical TV.
+Carabiner is an Electron desktop app for streaming device development and QA. It shows live video from a capture card (HDMI capture device) in a floating overlay window, while letting users control Roku devices via ECP (HTTP), Android/Fire TV/Google TV devices via ADB, Apple TV via `atvremote` (pyatv), or Xumo Stream Box / RDK devices via the RDK Services JSON-RPC API (`org.rdk.RDKShell`). Primary users are developers testing streaming apps without a physical TV.
 
 ## Workflow
 
@@ -47,7 +47,7 @@ IPC routing: the main process listens on `shared-window-channel` (synchronous `s
 Pure vanilla JS — no React. Manages:
 - `getUserMedia` for the capture card video stream
 - Device monitoring via `navigator.mediaDevices.addEventListener("devicechange")` with a 3-second debounce for reconnect recovery
-- Keyboard → ECP/ADB key translation (`ecpKeysMap`, `adbKeysMap`)
+- Keyboard → ECP/ADB/ATV/RDK key translation (`ecpKeysMap`, `adbKeysMap`, `atvKeysMap`, `rdkKeysMap`)
 - Screenshot capture (canvas), video recording (`MediaRecorder`)
 - Overlay image rendering
 
@@ -61,7 +61,7 @@ React 17 app using React Bootstrap tabs. `App.js` is the root; each tab is a com
 |-----------|-----------|---------|
 | General | `GeneralSection` | Capture device picker + link to streaming device |
 | Display | `DisplaySection` | Border, transparency, window options |
-| Control | `ControlSection` | Add/remove Roku, Android, and Apple TV streaming devices |
+| Control | `ControlSection` | Add/remove Roku, Android, Apple TV, and Xumo (RDK) streaming devices |
 | Overlay | `OverlaySection` | Load reference image for UI comparison |
 | Files | `FilesSection` | Default save paths for screenshots/recordings |
 | Automation | `AutomationSection` | Script recording, playback management, and step editing |
@@ -78,10 +78,11 @@ The React app communicates with the main process via `window.electronAPI` (expos
 | `settings.js` | Load/save `settings.json` from `app.getPath("userData")` |
 | `adb.js` | Wraps `adb connect/disconnect/shell input keyevent` via `child_process.exec` |
 | `appletv.js` | Wraps `atvremote` CLI (pyatv) for Apple TV key sending and text input via `child_process.spawn` |
-| `menu.js` | macOS menu bar, system tray (Win/macOS), right-click context menu; includes Control Device quick-switch submenu and Automation scripts submenu |
+| `rdk.js` | Talks JSON-RPC over HTTP to RDK Services' `org.rdk.RDKShell` plugin (`injectKey`, `launchApplication`) for Xumo Stream Box / RDK devices. Exposes `connectRDK`/`disconnectRDK`/`testRDKConnection`/`sendRDKKey`/`sendRDKText`/`launchRDKApp`. Optional Bearer token. |
+| `menu.js` | macOS menu bar, system tray (Win/macOS), right-click context menu; includes Control Device quick-switch submenu, Automation scripts submenu, and a "Check for Updates..." item |
 | `updater.js` | Polls GitHub Releases API; shows dialog if newer version found |
 | `mcp-server.js` | Embedded MCP server (localhost `127.0.0.1` only). Exposes `startMcpServer(ctx)`/`stopMcpServer()`; serves Streamable HTTP at `/mcp` and legacy SSE at `/sse` via Node's built-in `http`. Optional Bearer-token auth. The `@modelcontextprotocol/sdk` ships a CJS build, so it is `require`d directly. |
-| `mcp-tools.js` | MCP tool/resource/prompt registration (`registerAll(server, ctx)`) — thin wrappers over `ctx`. Holds the semantic→native key map used by `send_key`. |
+| `mcp-tools.js` | MCP tool/resource/prompt registration (`registerAll(server, ctx)`) — thin wrappers over `ctx`. Holds the semantic→native key map (ecp/adb/atv/rdk) used by `send_key`, and registers the RDK-only `launch_app` tool. |
 
 ### IPC Message Types (`shared-window-channel`)
 
@@ -89,9 +90,10 @@ Key message types handled in `main.js`:
 - `set-capture-devices` — updates tray menu with available capture cards
 - `set-video-stream` — starts capture stream on display window (forwarded only if display is visible)
 - `set-transparency`, `set-resolution`, `set-border-*`, `set-display-size` — visual settings
-- `set-control-list` / `set-control-selected` — streaming device CRUD + ADB/ATV connect/disconnect
+- `set-control-list` / `set-control-selected` — streaming device CRUD + ADB/ATV/RDK connect/disconnect
 - `send-adb-key` / `send-adb-text` — forwarded to `adb.js`
 - `send-atv-key` / `send-atv-text` — forwarded to `appletv.js`
+- `send-rdk-key` / `send-rdk-text` — forwarded to `rdk.js`
 - `set-adb-path` / `set-atv-path` — update paths to the `adb` and `atvremote` binaries
 - `set-audio-enabled` — toggles audio in the display window
 - `set-show-keystrokes` — toggles the on-screen key indicator overlay
@@ -101,20 +103,22 @@ Separate `ipcMain.on`/`ipcMain.handle` channels (outside `shared-window-channel`
 - Script recording lifecycle: `start-script-recording`, `stop-script-recording`, `save-script`, `run-script`, `stop-script`, `script-playback-started`, `script-playback-done`
 - Script management: `get-scripts`, `update-script-name`, `update-script-steps`, `delete-script`
 - File dialogs: `save-screenshot-dialog`, `save-video-dialog`, `select-adb-path`, `select-atv-path`, `load-image`, `load-image-by-path`
+- RDK (Xumo): `test-rdk-connection` (reachability/auth check from the Control tab's Test button), `launch-rdk-app` (RDKShell `launchApplication`)
 - Settings persistence: `save-shortcut`, `save-launch-app-at-login`, `save-always-on-top`, `save-dark-mode`, etc.
 - MCP server: `save-mcp-config` / `get-mcp-status` (start/stop the server live, persist `settings.mcp`), `save-video-direct` (non-dialog recording save used by MCP). The main↔display renderer RPC for MCP uses `mcp-rpc-request` (main → display: `{requestId, action, params}`) and `mcp-rpc-response` (display → main: `{requestId, result|error}`); `action` is one of `capture-screenshot`, `send-key`, `send-text`, `start-recording`, `stop-recording`.
 
 ### MCP Server
 
-`settings.mcp = { enabled, port, token }`. When enabled (toggle in the MCP tab → `MCPSection.js`), `main.js` starts `mcp-server.js` after the windows are created and stops it on `before-quit`. Tool handlers never import main directly — they call a `ctx` object built in `main.js` that reuses the existing internals (`switchControlDevice`, `startScriptPlayback`, ADB/ATV send fns, `settings`, menu refreshers) and the `callDisplay()` RPC helper for renderer-side work (canvas screenshot, `MediaRecorder`, key/text sending). `run_script` blocks by storing a resolver keyed by script id and settling it in the existing `script-playback-done` handler. See `docs/mcp-server.md` for the full tool/resource/prompt reference and agent usage.
+`settings.mcp = { enabled, port, token }`. When enabled (toggle in the MCP tab → `MCPSection.js`), `main.js` starts `mcp-server.js` after the windows are created and stops it on `before-quit`. Tool handlers never import main directly — they call a `ctx` object built in `main.js` that reuses the existing internals (`switchControlDevice`, `startScriptPlayback`, ADB/ATV/RDK send fns, `launchRDKApp`, `settings`, menu refreshers) and the `callDisplay()` RPC helper for renderer-side work (canvas screenshot, `MediaRecorder`, key/text sending). The `launch_app` MCP tool maps to `ctx.launchApp` and is RDK-only. `run_script` blocks by storing a resolver keyed by script id and settling it in the existing `script-playback-done` handler. See `docs/mcp-server.md` for the full tool/resource/prompt reference and agent usage.
 
 ### Device Control Protocols
 
 - **Roku (ECP)**: HTTP POST to `http://<ip>:8060/keypress|keydown|keyup/<key>`. Sent directly from the display window renderer via `fetch`.
 - **Android/Fire TV/Google TV (ADB)**: `adb shell input keyevent <code>` or `adb shell input text <text>`. Routed through main process → `adb.js`.
 - **Apple TV (ATV)**: `atvremote --id <deviceId> --protocol mrp <key>` or `atvremote --id <deviceId> text_append=<text>`. Routed through main process → `appletv.js`. Requires `atvremote` binary from the [pyatv](https://pyatv.dev/) package.
+- **Xumo Stream Box (RDK)** *(experimental)*: HTTP JSON-RPC to RDK Services' `org.rdk.RDKShell.1.injectKey` (Linux input keycodes) / `.launchApplication`. Routed through main process → `rdk.js`. Connection is configured per-device (`host`, `port` default `9998`, optional Bearer `token`) rather than via a CLI binary; text input is sent character-by-character as injected keys.
 
-The device ID string format encodes protocol: `"<ip>|ecp"`, `"<ip>|adb"`, or `"<uuid-or-mac>|atv"`.
+The device ID string format encodes protocol: `"<ip>|ecp"`, `"<ip>|adb"`, `"<uuid-or-mac>|atv"`, or `"<host:port>|rdk"`.
 
 ### Automation / Script System
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 # Carabiner
 
-**Carabiner** is a powerful video capture and remote control application designed for streaming device development and testing. It provides seamless control of Roku, Android-based streaming devices (Fire TV, Google TV, Android TV), and Apple TV through an intuitive floating and resizable window interface.
+**Carabiner** is a powerful video capture and remote control application designed for streaming device development and testing. It provides seamless control of Roku, Android-based streaming devices (Fire TV, Google TV, Android TV), Apple TV, and Xumo Stream Box (RDK, experimental) through an intuitive floating and resizable window interface.
 
 <p align="center">
   <img src="https://img.shields.io/badge/Roku-662D91?style=for-the-badge&logo=roku&logoColor=white" alt="Roku" height="42px" />
@@ -27,7 +27,7 @@ Perfect for developers and QA engineers who need to test streaming applications 
 
 ### Core Functionality
 
-- **Multi-Device Support**: Control Roku, Android-based devices (Fire TV, Google TV, Android TV) and Apple TV
+- **Multi-Device Support**: Control Roku, Android-based devices (Fire TV, Google TV, Android TV), Apple TV, and Xumo Stream Box (RDK, experimental)
 - **Real-time Video Capture**: View your streaming device output directly on your computer
 - **Video Recording**: Record streaming device sessions in MP4/WebM format for documentation and testing
 - **Keyboard Control**: Use your computer keyboard to navigate and control devices
@@ -93,6 +93,7 @@ We welcome contributions to make Carabiner better! Here's how you can help:
 - **[Roku External Control Protocol (ECP)](https://developer.roku.com/docs/developer-program/dev-tools/external-control-api.md)**: Roku device communication
 - **[Android Debug Bridge (ADB)](https://developer.android.com/tools/adb)**: Android device communication
 - **[pyatv](https://pyatv.dev/)**: Apple TV device communication via Media Remote Protocol (MRP)
+- **[RDK Services](https://rdkcentral.github.io/rdkservices/)**: Xumo Stream Box / RDK device communication via the `org.rdk.RDKShell` JSON-RPC API
 
 ## Acknowledgments
 

--- a/docs/building-from-source.md
+++ b/docs/building-from-source.md
@@ -96,6 +96,7 @@ carabiner/
 │   ├── settings.js              # Load/save settings.json from userData
 │   ├── adb.js                   # Android/Fire TV/Google TV control via ADB
 │   ├── appletv.js               # Apple TV control via atvremote (pyatv)
+│   ├── rdk.js                   # Xumo Stream Box / RDK control via RDKShell JSON-RPC
 │   ├── mcp-server.js            # Embedded MCP server (localhost) — HTTP/SSE transports
 │   ├── mcp-tools.js             # MCP tool/resource/prompt registration
 │   └── updater.js               # GitHub Releases version check
@@ -105,7 +106,7 @@ carabiner/
 │   └── components/              # One component per settings tab
 │       ├── GeneralSection.js    # Capture device picker and device link
 │       ├── DisplaySection.js    # Border, transparency, window options
-│       ├── ControlSection.js    # Add/remove Roku, Android, and Apple TV devices
+│       ├── ControlSection.js    # Add/remove Roku, Android, Apple TV, and Xumo (RDK) devices
 │       ├── AutomationSection.js # Script recording, playback, and step editing
 │       ├── OverlaySection.js    # Reference image overlay with opacity control
 │       ├── FilesSection.js      # Default save paths for screenshots/recordings
@@ -158,6 +159,7 @@ carabiner/
 - **[Roku ECP API](https://developer.roku.com/docs/developer-program/dev-tools/external-control-api.md)**: For Roku device control
 - **[Android ADB](https://developer.android.com/tools/adb)**: For Android/Fire TV/Google TV device control
 - **[pyatv (atvremote)](https://pyatv.dev/)**: For Apple TV device control
+- **[RDK Services (RDKShell)](https://rdkcentral.github.io/rdkservices/)**: For Xumo Stream Box / RDK device control (experimental)
 - **[Model Context Protocol](https://modelcontextprotocol.io/)**: Protocol behind the embedded MCP server
 
 ## Next Steps

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -10,7 +10,7 @@ Carabiner is available for macOS, Windows, and Linux. Download the latest instal
 
 - **Operating System**: macOS 10.14+, Windows 10+, or Linux (Ubuntu 18.04+)
 - **Capture Devices**: Video capture device (USB capture card, webcam, etc.)
-- **Streaming Devices**: Roku, Android-based devices (Fire TV, Google TV, Android TV), Apple TV
+- **Streaming Devices**: Roku, Android-based devices (Fire TV, Google TV, Android TV), Apple TV, Xumo Stream Box (RDK, experimental)
 
 ## Setup Prerequisites
 
@@ -47,6 +47,12 @@ Carabiner is available for macOS, Windows, and Linux. Download the latest instal
 2. **Allow AirPlay Access**: Ensure AirPlay is enabled on your Apple TV for control to work properly:
    - Go to `Settings` > `AirPlay & Apple Home`
    - Expand `Allow Access` and pick `Anyone on the Same Network`
+
+### For Xumo Stream Box (RDK) — experimental
+
+1. **RDK Services**: The device must expose the `org.rdk.RDKShell` JSON-RPC endpoint (default port `9998`) reachable from your computer
+2. **Add the Device**: In the **Control** tab pick **Xumo (RDK)**, enter the device IP, port, and optional auth token, then use **Test** to verify — see the [Usage Guide](./usage-guide.md#xumo-stream-box-rdk-configuration-experimental)
+   - No external tool binary is required
 
 ## Installation Steps
 

--- a/docs/key-mappings.md
+++ b/docs/key-mappings.md
@@ -1,45 +1,47 @@
 # Control Keyboard Mappings
 
-This document provides an overview of the key mappings defined in `ecpKeysMap`, `adbKeysMap` and `atvKeysMap` at the file [render.js](../public/render.js).
+This document provides an overview of the key mappings defined in `ecpKeysMap`, `adbKeysMap`, `atvKeysMap` and `rdkKeysMap` at the file [render.js](../public/render.js).
 
 - For Google TV and Fire TV setup instructions see the [Android / Fire TV setup guide](./setup-android-firetv.md).
 - For Apple TV setup and pairing instructions see the [Apple TV setup guide](./setup-apple-tv.md).
+- RDK key codes are Linux input event codes injected via `org.rdk.RDKShell` (Xumo Stream Box / RDK devices, experimental).
 
 ## Key Mappings Table
 
-| Key Combination          | ECP Key Code  | ADB Key Code | ATV Command  | Device Control           |
-|--------------------------|---------------|--------------|--------------|--------------------------|
-| ArrowUp                  | up            | 19           | up           | D-Pad Up                 |
-| ArrowDown                | down          | 20           | down         | D-Pad Down               |
-| ArrowLeft                | left          | 21           | left         | D-Pad Left               |
-| ArrowRight               | right         | 22           | right        | D-Pad Right              |
-| Enter                    | select        | 66           | select       | OK/Select Button         |
-| Escape                   | back          | 4            | menu         | Back Button              |
-| Delete                   | back          | 4            | menu         | Back Button              |
-| Home                     | home          | 3            | home         | Home Button              |
-| Shift+Escape             | home          | 3            | home         | Home Button              |
-| Control+Escape           | home          | 3            | home         | Home Button              |
-| Backspace                | instantreplay | 67           | N/A          | Backspace Action         |
-| End                      | play          | 85           | play_pause   | Play/Pause Button        |
-| PageUp                   | rev           | 89           | volume_up    | Rewind / Vol Up ²        |
-| PageDown                 | fwd           | 90           | volume_down  | Forward / Vol Down ²     |
-| Insert                   | info          | 1            | top_menu     | Info/Menu Button         |
-| Control+KeyA             | a             | N/A          | N/A          | Game Remote A Button     |
-| Control+KeyZ             | b             | N/A          | N/A          | Game Remote B Button     |
-| F10                      | volumemute    | 164          | N/A          | Volume Mute Button       |
-| Command+Backspace (Mac)  | backspace     | 67           | N/A          | Backspace Action         |
-| Command+Enter (Mac)      | play          | 85           | play_pause   | Play/Pause Button        |
-| Command+ArrowLeft (Mac)  | rev           | 89           | previous     | Rewind / Previous ²      |
-| Command+ArrowRight (Mac) | fwd           | 90           | next         | Forward / Next ²         |
-| Command+Digit8 (Mac)     | info          | 1            | N/A          | Info/Menu Button         |
-| Control+Backspace (Win)  | backspace     | 67           | N/A          | Backspace Action         |
-| Control+Enter (Win)      | play          | 85           | play_pause   | Play/Pause Button        |
-| Control+ArrowLeft (Win)  | rev           | 89           | previous     | Rewind / Previous ²      |
-| Control+ArrowRight (Win) | fwd           | 90           | next         | Forward / Next ²         |
-| Control+Digit8 (Win)     | info          | 1            | N/A          | Info/Menu Button         |
+| Key Combination          | ECP Key Code  | ADB Key Code | ATV Command  | RDK Key Code | Device Control           |
+|--------------------------|---------------|--------------|--------------|--------------|--------------------------|
+| ArrowUp                  | up            | 19           | up           | 103          | D-Pad Up                 |
+| ArrowDown                | down          | 20           | down         | 108          | D-Pad Down               |
+| ArrowLeft                | left          | 21           | left         | 105          | D-Pad Left               |
+| ArrowRight               | right         | 22           | right        | 106          | D-Pad Right              |
+| Enter                    | select        | 66           | select       | 28           | OK/Select Button         |
+| Escape                   | back          | 4            | menu         | 158          | Back Button              |
+| Delete                   | back          | 4            | menu         | 158          | Back Button              |
+| Home                     | home          | 3            | home         | 102          | Home Button              |
+| Shift+Escape             | home          | 3            | home         | 102          | Home Button              |
+| Control+Escape           | home          | 3            | home         | 102          | Home Button              |
+| Backspace                | instantreplay | 67           | N/A          | 14           | Backspace Action ³       |
+| End                      | play          | 85           | play_pause   | 164          | Play/Pause Button        |
+| PageUp                   | rev           | 89           | volume_up    | 168          | Rewind / Vol Up ²        |
+| PageDown                 | fwd           | 90           | volume_down  | 208          | Forward / Vol Down ²     |
+| Insert                   | info          | 1            | top_menu     | 139          | Info/Menu Button         |
+| Control+KeyA             | a             | N/A          | N/A          | N/A          | Game Remote A Button     |
+| Control+KeyZ             | b             | N/A          | N/A          | N/A          | Game Remote B Button     |
+| F10                      | volumemute    | 164          | N/A          | 113          | Volume Mute Button       |
+| Command+Backspace (Mac)  | backspace     | 67           | N/A          | N/A          | Backspace Action         |
+| Command+Enter (Mac)      | play          | 85           | play_pause   | 164          | Play/Pause Button        |
+| Command+ArrowLeft (Mac)  | rev           | 89           | previous     | 168          | Rewind / Previous ²      |
+| Command+ArrowRight (Mac) | fwd           | 90           | next         | 208          | Forward / Next ²         |
+| Command+Digit8 (Mac)     | info          | 1            | N/A          | N/A          | Info/Menu Button         |
+| Control+Backspace (Win)  | backspace     | 67           | N/A          | N/A          | Backspace Action         |
+| Control+Enter (Win)      | play          | 85           | play_pause   | 164          | Play/Pause Button        |
+| Control+ArrowLeft (Win)  | rev           | 89           | previous     | 168          | Rewind / Previous ²      |
+| Control+ArrowRight (Win) | fwd           | 90           | next         | 208          | Forward / Next ²         |
+| Control+Digit8 (Win)     | info          | 1            | N/A          | N/A          | Info/Menu Button         |
 
 **Notes:**
 
-- Carabiner also handles literal keyboard characters (letters, numbers, printable chars).
-- ² The Device Control action differs by protocol: the first label applies to ECP/ADB, the second to ATV.
+- Carabiner also handles literal keyboard characters (letters, numbers, printable chars). On RDK, digit keys `0`–`9` map to their input keycodes (`11` for `0`, `2`–`10` for `1`–`9`).
+- ² The Device Control action differs by protocol: the first label applies to ECP/ADB/RDK, the second to ATV.
+- ³ On RDK the plain `Backspace` key maps to keycode `14` (Backspace); the `Cmd/Ctrl+Backspace` combos have no RDK mapping.
 - N/A means the key has no mapping for that protocol and will be ignored.

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -3,8 +3,8 @@
 Carabiner can expose its device-control, automation, and capture features to AI assistants through
 an embedded [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server. This turns
 Carabiner into an **AI-native QA tool**: an agent (Claude Code, Claude Desktop, Cursor, etc.) can
-navigate a Roku / Fire TV / Apple TV app, capture screenshots, run automation scripts, and validate
-UI state without a human in the loop.
+navigate a Roku / Fire TV / Apple TV / Xumo Stream Box (RDK) app, capture screenshots, run
+automation scripts, and validate UI state without a human in the loop.
 
 The server runs inside Carabiner's main process and **binds only to `127.0.0.1`** — it is never
 exposed to the network.
@@ -78,10 +78,11 @@ field.
 | Tool | Description |
 |------|-------------|
 | `list_devices` | All configured control devices with protocol and connection status |
-| `select_device` | Switch the active device by id (`<ip>\|ecp`, `<ip>\|adb`, `<uuid-or-mac>\|atv`) |
+| `select_device` | Switch the active device by id (`<ip>\|ecp`, `<ip>\|adb`, `<uuid-or-mac>\|atv`, `<host:port>\|rdk`) |
 | `send_key` | Send one keypress (see [Keys](#keys)) |
 | `send_text` | Type a string on the current device |
 | `get_current_device` | Protocol, address, and connection state of the active device |
+| `launch_app` | Launch an application by client name (and optional URI). **RDK (Xumo) only** — uses `RDKShell.launchApplication` |
 
 ### Capture & recording
 | Tool | Description |
@@ -128,9 +129,10 @@ field.
 
 `send_key` accepts friendly, protocol-agnostic names that are translated to each device's native
 key: `up`, `down`, `left`, `right`, `select`/`ok`, `back`, `home`, `play`/`pause`, `rewind`,
-`forward`, `replay`, `info`, `volume_up`, `volume_down`, `volume_mute`. You may also pass a raw
-protocol-native key (a Roku ECP command such as `search`, an ADB keycode, or an Apple TV command)
-and it will be forwarded as-is. Keys not available on the active protocol return an error.
+`forward`, `replay`, `info`/`options`, `volume_up`, `volume_down`, `volume_mute`. You may also pass
+a raw protocol-native key (a Roku ECP command such as `search`, an ADB keycode, an Apple TV command,
+or an RDK Linux input keycode such as `28`) and it will be forwarded as-is. Keys not available on the
+active protocol return an error (e.g. `replay` is ECP-only, `volume_up`/`volume_down` are not on ECP).
 
 ## Driving QA test cases with an AI agent
 
@@ -166,7 +168,8 @@ take_screenshot()
 ```
 
 > Step `mod` values follow Carabiner's automation format: `-1` = full keypress (ECP), `0` = press
-> for ADB/ATV, `100` = key-up. `delay` is milliseconds to wait *before* the step.
+> for ADB/ATV/RDK, `100` = key-up. `create_script` accepts a `controlType` of `ecp`, `adb`, `atv`,
+> or `rdk`. `delay` is milliseconds to wait *before* the step.
 
 ## Scheduling test runs externally
 

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -18,11 +18,13 @@ After installing Carabiner, launch the application to access the settings window
 ### 2. Add Streaming Devices
 
 1. Navigate to the **Control** tab
-2. Enter the device details:
-   - **IP Address / Device ID**: IP for Roku, Fire TV, and Google TV; UUID or MAC address for Apple TV
+2. Select the device **Type** from the dropdown — the fields below adapt to the type you pick:
+   - **Roku (ECP)**, **Fire TV (ADB)**, **Google TV (ADB)**, **Apple TV (atvremote)**, or **Xumo (RDK)** *(experimental)*
+3. Enter the device details:
+   - **IP Address / Device ID**: IP for Roku, Fire TV, Google TV, and Xumo; UUID or MAC address for Apple TV
    - **Alias**: A friendly name for the device
-   - **Type**: Select Roku, Fire TV, Google TV, or Apple TV
-3. Click **+** to register the device
+   - For **Xumo (RDK)** also set the **RDK JSON-RPC** port (default `9998`) and an optional auth **token**; use the **Test** button to verify the connection
+4. Click **+** to register the device
 
 > [!NOTE]
 > **Roku users — enable ECP first:** Carabiner communicates with Roku devices via the External Control Protocol (ECP). Before adding a Roku device, make sure ECP is enabled:
@@ -127,7 +129,7 @@ The **Automation** tab lets you record key sequences (with the exact timing betw
 - Click **Save Changes** to apply edits or **Cancel** to revert.
 - Click **🗑** to delete a script entirely.
 
-> **Note:** Scripts are tied to the protocol of the device that was active when they were recorded (ECP for Roku, ADB for Android). Playing a script on a device with a different protocol will show a warning toast, but playback will still proceed.
+> **Note:** Scripts are tied to the protocol of the device that was active when they were recorded (ECP for Roku, ADB for Android, atvremote for Apple TV, RDK for Xumo). Playing a script on a device with a different protocol will show a warning toast, but playback will still proceed.
 
 ### AI Automation (MCP Server)
 
@@ -208,6 +210,18 @@ For Apple TV devices, install **pyatv** and pair once before adding the device:
 4. Click **+** to add the device
 
 See the [Apple TV setup guide](./setup-apple-tv.md) for detailed instructions on installing `pyatv` and pairing your Apple TV.
+
+### Xumo Stream Box (RDK) Configuration *(experimental)*
+
+Xumo Stream Box and other RDK-based devices are controlled directly over the RDK Services JSON-RPC API (`org.rdk.RDKShell`) — no extra tool binary is required:
+
+1. Open the **Control** tab and choose **Xumo (RDK)** as the device type
+2. Enter the device's **IP address** and the **RDK JSON-RPC** port (default `9998`)
+3. If the device requires authentication, enter the Bearer **token**
+4. Click **Test** to verify the endpoint is reachable, then **+** to add the device
+
+> [!NOTE]
+> RDK support is **experimental**. The device must have the `org.rdk.RDKShell` plugin enabled and its JSON-RPC endpoint reachable from your computer. Text input is sent as individual injected keystrokes.
 
 ## Getting Help
 


### PR DESCRIPTION
## Summary

PR #95 added experimental Xumo Stream Box (RDK) device control across the codebase (`rdk.js`, `mcp-tools.js` `launch_app` + rdk semantic-key map, `main.js` `ctx`, `render.js` routing) but did **not** update any documentation. This PR brings all repo docs in line with the current state of the app.

**No code changes** — documentation only. The MCP server itself was already complete for RDK; the only gap was the docs.

## Changes

- **docs/mcp-server.md** — Xumo in intro, `launch_app` tool row, `<host:port>|rdk` id format in `select_device`, RDK in the Keys section, `rdk` `controlType` for `create_script`
- **.claude/CLAUDE.md** — RDK in "What This App Does", key-map list, Control tab, new `rdk.js` module row, `send-rdk-key/text` IPC, `test-rdk-connection`/`launch-rdk-app` handlers, MCP `ctx` + `launch_app`, RDK protocol section + `|rdk` id format, "Check for Updates" menu mention
- **README.md** — Xumo (RDK, experimental) in intro/features, RDK Services in technology stack
- **docs/usage-guide.md** — device-type dropdown list, new "Xumo Stream Box (RDK) Configuration" section, updated script-protocol note
- **docs/key-mappings.md** — added **RDK Key Code** column to the mappings table + RDK-specific notes
- **docs/installation.md** — device list + new RDK prerequisites section
- **docs/building-from-source.md** — `rdk.js` in the file tree, RDK Services in tech list

RDK is consistently labeled **experimental** throughout, matching the feature's status.

## Test plan

- [x] Docs-only change; reviewed all Markdown in the repo against current code
- [x] Cross-checked RDK key codes against `rdkKeysMap` in `render.js`
- [x] Verified the usage-guide anchor linked from installation.md resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)