### PR TITLE
Add SSDP network discovery for Roku devices

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "2.1.2",
       "license": "MIT",
       "dependencies": {
+        "@lvcabral/node-ssdp": "^4.0.4",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "auto-launch": "^5.0.6",
         "bootstrap": "5.1.3",
@@ -4954,6 +4955,40 @@
         "node": ">=18"
       }
     },
+    "node_modules/@lvcabral/node-ssdp": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@lvcabral/node-ssdp/-/node-ssdp-4.0.4.tgz",
+      "integrity": "sha512-/hWGfZ50HpqZA8lZACe6/QP+M3l8heKCVu8nYMuhMUMdoK5NS+f+frhAy5WT5vJ/TgIoH+bOVOn6ytT7A39T4g==",
+      "license": "MIT",
+      "dependencies": {
+        "async": "^2.6.0",
+        "bluebird": "^3.5.1",
+        "debug": "^3.1.0",
+        "extend": "^3.0.1",
+        "neoip": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@lvcabral/node-ssdp/node_modules/async": {
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.14"
+      }
+    },
+    "node_modules/@lvcabral/node-ssdp/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
     "node_modules/@malept/cross-spawn-promise": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@malept/cross-spawn-promise/-/cross-spawn-promise-2.0.0.tgz",
@@ -8731,7 +8766,6 @@
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
       "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/body-parser": {
@@ -13052,6 +13086,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
     },
     "node_modules/external-editor": {
@@ -19046,7 +19086,6 @@
       "version": "4.18.1",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.debounce": {
@@ -19859,6 +19898,12 @@
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/neoip": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/neoip/-/neoip-3.1.0.tgz",
+      "integrity": "sha512-KtkXRRp1XK2BzJpLF7PRHyndphWn/bU5XkQFUJtAdm6rdUenkJZwQDpxifG+Q/7PLpxhc+wdcZiE15L/cZhnXA==",
       "license": "MIT"
     },
     "node_modules/nice-try": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "repo": "carabiner"
   },
   "dependencies": {
+    "@lvcabral/node-ssdp": "^4.0.4",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "auto-launch": "^5.0.6",
     "bootstrap": "5.1.3",

--- a/public/main.js
+++ b/public/main.js
@@ -35,6 +35,7 @@ const {
   launchRDKApp,
   testRDKConnection,
 } = require("./rdk");
+const { discoverRokuDevices } = require("./ssdp");
 const {
   createMacOSMenu,
   updateAlwaysOnTopMenuItem,
@@ -1037,6 +1038,15 @@ app.whenReady().then(async () => {
     try {
       const result = await launchRDKApp(client, uri);
       return { success: true, result };
+    } catch (err) {
+      return { success: false, error: err.message };
+    }
+  });
+
+  ipcMain.handle("discover-roku-devices", async (event, timeoutMs) => {
+    try {
+      const devices = await discoverRokuDevices(timeoutMs);
+      return { success: true, devices };
     } catch (err) {
       return { success: false, error: err.message };
     }

--- a/public/ssdp.js
+++ b/public/ssdp.js
@@ -1,0 +1,114 @@
+/*---------------------------------------------------------------------------------------------
+ *  Carabiner - Simple Screen Capture and Remote Control App for Streaming Devices
+ *
+ *  Repository: https://github.com/lvcabral/carabiner
+ *
+ *  Copyright (c) 2024-2026 Marcelo Lv Cabral. All Rights Reserved.
+ *
+ *  Licensed under the MIT License. See LICENSE in the repository root for license information.
+ *--------------------------------------------------------------------------------------------*/
+const http = require("http");
+const SsdpClient = require("@lvcabral/node-ssdp").Client;
+
+const ECP_PORT = 8060;
+
+// Pull the text content of a single XML tag out of a Roku device-info response.
+function getXmlTag(xml, tag) {
+  const match = xml.match(new RegExp(`<${tag}>([^<]*)</${tag}>`, "i"));
+  return match ? match[1].trim() : "";
+}
+
+// Strip the word "Roku" from a device name so it reads well as an alias.
+function buildAlias(name) {
+  return name.replace(/\broku\b/gi, "").replace(/\s{2,}/g, " ").trim();
+}
+
+// Fetch http://<ip>:8060/query/device-info and derive a friendly name + alias.
+// Resolves to a device record even on failure (falling back to the IP).
+function fetchDeviceInfo(ipAddress, timeoutMs = 2000) {
+  return new Promise((resolve) => {
+    const fallback = () => {
+      const name = `Roku ${ipAddress}`;
+      resolve({ ipAddress, name, alias: buildAlias(name), model: "" });
+    };
+    const req = http.request(
+      {
+        host: ipAddress,
+        port: ECP_PORT,
+        path: "/query/device-info",
+        method: "GET",
+        timeout: timeoutMs,
+      },
+      (res) => {
+        let data = "";
+        res.setEncoding("utf8");
+        res.on("data", (chunk) => (data += chunk));
+        res.on("end", () => {
+          if (res.statusCode < 200 || res.statusCode >= 300) {
+            fallback();
+            return;
+          }
+          const userName = getXmlTag(data, "user-device-name");
+          const friendlyName = getXmlTag(data, "friendly-device-name");
+          const model = getXmlTag(data, "friendly-model-name") || getXmlTag(data, "model-name");
+          const name = userName || friendlyName || model || `Roku ${ipAddress}`;
+          resolve({ ipAddress, name, alias: buildAlias(name), model });
+        });
+      }
+    );
+    req.on("timeout", () => req.destroy(new Error("timeout")));
+    req.on("error", fallback);
+    req.end();
+  });
+}
+
+// Discover Roku devices on the LAN via SSDP (search target "roku:ecp").
+// Always resolves to an array; never rejects.
+function discoverRokuDevices(timeoutMs = 3000) {
+  return new Promise((resolve) => {
+    const found = new Map(); // ipAddress -> true (dedupe by IP)
+    let client;
+    try {
+      client = new SsdpClient();
+    } catch (err) {
+      console.warn(`SSDP client init failed: ${err.message}`);
+      resolve([]);
+      return;
+    }
+
+    client.on("response", (headers, statusCode, rinfo) => {
+      const ip = rinfo && rinfo.address;
+      if (ip && !found.has(ip)) {
+        found.set(ip, true);
+      }
+    });
+
+    try {
+      client.search("roku:ecp");
+    } catch (err) {
+      console.warn(`SSDP search failed: ${err.message}`);
+      try {
+        client.stop();
+      } catch {}
+      resolve([]);
+      return;
+    }
+
+    setTimeout(async () => {
+      try {
+        client.stop();
+      } catch {}
+      try {
+        const devices = await Promise.all([...found.keys()].map((ip) => fetchDeviceInfo(ip)));
+        resolve(devices);
+      } catch (err) {
+        console.warn(`SSDP enrichment failed: ${err.message}`);
+        resolve([]);
+      }
+    }, timeoutMs);
+  });
+}
+
+module.exports = {
+  discoverRokuDevices,
+};

--- a/src/App.css
+++ b/src/App.css
@@ -274,6 +274,32 @@ body {
   color: #fff !important;
 }
 
+/* Modals */
+/* The full-viewport .modal container carries data-bs-theme; keep it transparent
+   so the global dark background rule doesn't hide the dimmed window behind it. */
+[data-bs-theme="dark"].modal {
+  background-color: transparent !important;
+}
+
+[data-bs-theme="dark"] .modal-content {
+  background-color: #343a40 !important;
+  border-color: #495057 !important;
+  color: #fff !important;
+}
+
+[data-bs-theme="dark"] .modal-header,
+[data-bs-theme="dark"] .modal-footer {
+  border-color: #495057 !important;
+}
+
+[data-bs-theme="dark"] .modal-title {
+  color: #fff !important;
+}
+
+[data-bs-theme="dark"] .modal-header .btn-close {
+  filter: invert(1) grayscale(100%) brightness(200%) !important;
+}
+
 /* Scrollable containers */
 [data-bs-theme="dark"] div[style*="border: 1px solid #dee2e6"] {
   border-color: #6c757d !important;

--- a/src/components/ControlSection.js
+++ b/src/components/ControlSection.js
@@ -14,6 +14,9 @@ import Button from "react-bootstrap/Button";
 import Row from "react-bootstrap/Row";
 import Col from "react-bootstrap/Col";
 import Alert from "react-bootstrap/Alert";
+import Modal from "react-bootstrap/Modal";
+import ListGroup from "react-bootstrap/ListGroup";
+import Spinner from "react-bootstrap/Spinner";
 
 const { electronAPI } = window;
 
@@ -29,6 +32,11 @@ function ControlSection({ streamingDevices, onUpdateStreamingDevices, onDeletedD
   const [rdkTestStatus, setRdkTestStatus] = useState("");
   const [repoUrl, setRepoUrl] = useState("");
   const [errorMessage, setErrorMessage] = useState("");
+  const [showDiscoverModal, setShowDiscoverModal] = useState(false);
+  const [discovering, setDiscovering] = useState(false);
+  const [discoveredDevices, setDiscoveredDevices] = useState([]);
+  const [discoverError, setDiscoverError] = useState("");
+  const [theme, setTheme] = useState("light");
   const ipAddressRef = useRef(null);
 
   useEffect(() => {
@@ -170,6 +178,29 @@ function ControlSection({ streamingDevices, onUpdateStreamingDevices, onDeletedD
     }
   };
 
+  const handleDiscoverDevices = async () => {
+    setTheme(document.body.getAttribute("data-bs-theme") || "light");
+    setShowDiscoverModal(true);
+    setDiscovering(true);
+    setDiscoveredDevices([]);
+    setDiscoverError("");
+    const result = await electronAPI.invoke("discover-roku-devices", 3000);
+    if (result?.success) {
+      setDiscoveredDevices(result.devices || []);
+    } else {
+      setDiscoverError(result?.error || "Discovery failed.");
+    }
+    setDiscovering(false);
+  };
+
+  const handleSelectDiscovered = (device) => {
+    setIpAddress(device.ipAddress);
+    setAlias(device.alias || "");
+    setShowDiscoverModal(false);
+    setErrorMessage("");
+    ipAddressRef.current.focus();
+  };
+
   const handleDeviceSelect = (e) => {
     setSelectedDevice(e.target.value);
   };
@@ -244,6 +275,28 @@ function ControlSection({ streamingDevices, onUpdateStreamingDevices, onDeletedD
                     onChange={(e) => setAlias(e.target.value)}
                   />
                 </Col>
+                {deviceType === "roku" && (
+                  <Col xs="auto">
+                    <Button
+                      size="sm"
+                      title="Find Roku Devices"
+                      variant="primary"
+                      onClick={handleDiscoverDevices}
+                      disabled={discovering}
+                    >
+                      <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        width="1em"
+                        height="1em"
+                        fill="currentColor"
+                        viewBox="0 0 16 16"
+                        style={{ verticalAlign: "middle" }}
+                      >
+                        <path d="M11.742 10.344a6.5 6.5 0 1 0-1.397 1.398h-.001q.044.06.098.115l3.85 3.85a1 1 0 0 0 1.415-1.414l-3.85-3.85a1 1 0 0 0-.115-.1zM12 6.5a5.5 5.5 0 1 1-11 0 5.5 5.5 0 0 1 11 0" />
+                      </svg>
+                    </Button>
+                  </Col>
+                )}
                 <Col xs="auto">
                   <Button size="sm" title="Add Device" variant="primary" onClick={handleAddDevice}>
                     &#x271A;
@@ -426,6 +479,49 @@ function ControlSection({ streamingDevices, onUpdateStreamingDevices, onDeletedD
         </Alert>
       )}
 
+      <Modal
+        show={showDiscoverModal}
+        onHide={() => setShowDiscoverModal(false)}
+        centered
+        size="sm"
+        data-bs-theme={theme}
+      >
+        <Modal.Header closeButton>
+          <Modal.Title style={{ fontSize: "1rem" }}>Find Roku Devices</Modal.Title>
+        </Modal.Header>
+        <Modal.Body style={{ fontSize: "0.85rem" }}>
+          {discovering && (
+            <div className="d-flex align-items-center">
+              <Spinner animation="border" size="sm" className="me-2" />
+              Searching for Roku devices…
+            </div>
+          )}
+          {!discovering && discoverError && (
+            <Alert variant="danger" className="mb-0 p-2">
+              {discoverError}
+            </Alert>
+          )}
+          {!discovering && !discoverError && discoveredDevices.length === 0 && (
+            <div className="text-muted">No Roku devices found on the network.</div>
+          )}
+          {!discovering && discoveredDevices.length > 0 && (
+            <ListGroup>
+              {discoveredDevices.map((device) => (
+                <ListGroup.Item
+                  action
+                  key={device.ipAddress}
+                  onClick={() => handleSelectDiscovered(device)}
+                >
+                  <strong>{device.name}</strong>
+                  <div className="text-muted" style={{ fontSize: "0.75rem" }}>
+                    {device.ipAddress}
+                  </div>
+                </ListGroup.Item>
+              ))}
+            </ListGroup>
+          )}
+        </Modal.Body>
+      </Modal>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Adds a **search button** next to the IP field in the **Control** tab (Roku only, for now) that scans the local network via SSDP and lets the user pick a discovered device from a list. Selecting a device fills the **IP address** and **Alias** fields automatically, stripping the word "Roku" from the detected device name.

Uses the [`@lvcabral/node-ssdp`](https://www.npmjs.com/package/@lvcabral/node-ssdp) package for discovery.

## Changes

- **`public/ssdp.js`** (new) — `discoverRokuDevices()` runs an SSDP `roku:ecp` search, dedupes hits by IP, and enriches each via the Roku `query/device-info` endpoint to derive a friendly name (user name → friendly name → model) and a "Roku"-stripped alias. Always resolves to an array; never rejects.
- **`public/main.js`** — requires the new module and adds the `discover-roku-devices` IPC handler.
- **`src/components/ControlSection.js`** — adds the Roku-only search button (matches the ✚ button's blue style and dimensions, white inline-SVG magnifier) and a picker modal with searching / empty / error states. The modal is scoped to the active dark/light theme.
- **`src/App.css`** — dark-mode styling for modal elements.
- **`package.json`** — adds `@lvcabral/node-ssdp` dependency.

## Testing

- `npm run build` compiles cleanly.
- Verified discovery against a real network — found 4 Roku devices with correct names/aliases.
- Verified the modal dark theme, button styling, and that the dimmed window shows behind the modal.

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)