### PR TITLE
Fix SSDP discovery on Windows with multiple network adapters

### DIFF
--- a/public/ssdp.js
+++ b/public/ssdp.js
@@ -69,7 +69,11 @@ function discoverRokuDevices(timeoutMs = 3000) {
     const found = new Map(); // ipAddress -> true (dedupe by IP)
     let client;
     try {
-      client = new SsdpClient();
+      // explicitSocketBind binds each socket to its interface IP instead of
+      // 0.0.0.0, so multicast search/replies use the correct adapter. Without
+      // it, Windows hosts with multiple adapters (VPN/Hyper-V/WSL/etc.) only
+      // discover devices on the default-route interface.
+      client = new SsdpClient({ explicitSocketBind: true });
     } catch (err) {
       console.warn(`SSDP client init failed: ${err.message}`);
       resolve([]);


### PR DESCRIPTION
## Problem

SSDP discovery (Roku network discovery) returned **no devices on Windows 11** even when Roku devices were present and reachable on the LAN.

## Cause

The `node-ssdp` `Client` was created without options, so `explicitSocketBind` defaulted to falsy and each UDP socket bound to `0.0.0.0`. On Windows hosts with multiple network adapters (VPN, Hyper-V, WSL, VirtualBox, Docker, multiple NICs), the OS then routes the multicast `M-SEARCH` egress **and** the unicast replies through the default-route interface only. Roku devices on a non-default adapter's subnet never have their replies delivered to the socket, so discovery comes back empty.

## Fix

Pass `explicitSocketBind: true` so each socket binds to its interface's real IP. This makes multicast membership, the search egress, and reply reception happen on the correct adapter per NIC.

This mirrors the fix used in the sibling project [`brs-desktop`](https://github.com/lvcabral/brs-desktop) (`src/helpers/settings.js`), which creates its discovery client the same way.

## Testing

- Should be verified on a Windows 11 machine with multiple network adapters where discovery previously found nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)