### PR TITLE
Fix update dialog appearing after disabling Check for Updates

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -78,6 +78,50 @@ let isCurrentlyRecording = false;
 let isScriptRecording = false;
 let isScriptPlaying = false;
 let saveFlag = false;
+let updateCheckTimeout = null;
+let updateCheckInterval = null;
+
+// Schedule the automatic update checks (initial delayed check + recurring one).
+// No-op in dev or when the "Check for Updates" option is disabled. Safe to call
+// repeatedly — it tears down any existing timers first.
+function startUpdateChecks() {
+  stopUpdateChecks();
+  if (!app.isPackaged || settings.display.autoUpdate === false) {
+    return;
+  }
+  // Check for updates 30 seconds after app start
+  updateCheckTimeout = setTimeout(async () => {
+    try {
+      await checkForUpdates(settings);
+    } catch (error) {
+      console.error("Error checking for updates:", error);
+    }
+  }, 30000);
+
+  // Check for updates every 24 hours
+  updateCheckInterval = setInterval(
+    async () => {
+      try {
+        await checkForUpdates(settings);
+      } catch (error) {
+        console.error("Error checking for updates:", error);
+      }
+    },
+    24 * 60 * 60 * 1000
+  );
+}
+
+// Cancel any scheduled automatic update checks.
+function stopUpdateChecks() {
+  if (updateCheckTimeout) {
+    clearTimeout(updateCheckTimeout);
+    updateCheckTimeout = null;
+  }
+  if (updateCheckInterval) {
+    clearInterval(updateCheckInterval);
+    updateCheckInterval = null;
+  }
+}
 
 const appLauncher = new AutoLaunch({
   name: "Carabiner",
@@ -473,28 +517,7 @@ app.whenReady().then(async () => {
   }
 
   // Initialize version checking (only in production and if enabled)
-  if (app.isPackaged && settings.display.autoUpdate !== false) {
-    // Check for updates 30 seconds after app start
-    setTimeout(async () => {
-      try {
-        await checkForUpdates(settings);
-      } catch (error) {
-        console.error("Error checking for updates:", error);
-      }
-    }, 30000);
-
-    // Check for updates every 24 hours
-    setInterval(
-      async () => {
-        try {
-          await checkForUpdates(settings);
-        } catch (error) {
-          console.error("Error checking for updates:", error);
-        }
-      },
-      24 * 60 * 60 * 1000
-    );
-  }
+  startUpdateChecks();
 
   // Hide app when both windows are hidden in macOS (only in dock mode)
   if (isMacOS) {
@@ -927,6 +950,9 @@ app.whenReady().then(async () => {
   ipcMain.on("save-check-for-updates", (event, checkForUpdates) => {
     settings.display.autoUpdate = checkForUpdates;
     saveSettings(settings);
+    // Start/stop the scheduled checks live so toggling the option takes effect
+    // immediately instead of only on the next launch.
+    startUpdateChecks();
   });
 
   // Manual "Check for Updates" triggered from a menu — always runs (even in dev)
@@ -1587,6 +1613,7 @@ app.whenReady().then(async () => {
   app.on("before-quit", () => {
     isQuitting = true;
     stopSleepWatcher();
+    stopUpdateChecks();
     if (isMcpRunning()) {
       stopMcpServer();
     }

--- a/public/updater.js
+++ b/public/updater.js
@@ -71,6 +71,12 @@ function compareVersions(current, latest) {
 // is always shown (ignoring a previously skipped version) and the user is given
 // "up to date" / error feedback when there is nothing to download.
 function checkForUpdates(settings, interactive = false) {
+  // Honor the "Check for Updates" toggle for automatic checks. Interactive
+  // (manual menu) checks always run. This guards against an already-scheduled
+  // periodic check firing after the user disabled the option mid-session.
+  if (!interactive && settings && settings.display && settings.display.autoUpdate === false) {
+    return Promise.resolve({ updateAvailable: false, version: "v" + packageInfo.version });
+  }
   console.log("Checking for updates...");
   return new Promise((resolve, reject) => {
     // Get repository info from package.json

--- a/public/updater.js
+++ b/public/updater.js
@@ -74,7 +74,7 @@ function checkForUpdates(settings, interactive = false) {
   // Honor the "Check for Updates" toggle for automatic checks. Interactive
   // (manual menu) checks always run. This guards against an already-scheduled
   // periodic check firing after the user disabled the option mid-session.
-  if (!interactive && settings?.display?.autoUpdate === false) {
+  if (!interactive && settings?.display?.autoUpdate !== true) {
     return Promise.resolve({ updateAvailable: false, version: "v" + packageInfo.version });
   }
   console.log("Checking for updates...");

--- a/public/updater.js
+++ b/public/updater.js
@@ -74,7 +74,7 @@ function checkForUpdates(settings, interactive = false) {
   // Honor the "Check for Updates" toggle for automatic checks. Interactive
   // (manual menu) checks always run. This guards against an already-scheduled
   // periodic check firing after the user disabled the option mid-session.
-  if (!interactive && settings && settings.display && settings.display.autoUpdate === false) {
+  if (!interactive && settings?.display?.autoUpdate === false) {
     return Promise.resolve({ updateAvailable: false, version: "v" + packageInfo.version });
   }
   console.log("Checking for updates...");


### PR DESCRIPTION
## Problem

A user reported that with **Check for Updates** unchecked, the update dialog still appeared after the recurring timer elapsed.

## Root cause

The automatic update check was gated **only once, at startup** (`main.js`):

```js
if (app.isPackaged && settings.display.autoUpdate !== false) {
  setTimeout(...)                       // 30s after launch
  setInterval(..., 24h)
}
```

- `checkForUpdates()` in `updater.js` never re-checked `settings.display.autoUpdate` — it only honored `skipVersion`.
- The `save-check-for-updates` handler persisted the new value but there was **no `clearInterval`**, so the already-scheduled check kept firing.

Scenario the user hit: app launched with the option enabled (default `true`) → interval registered → user unchecked the option mid-session → setting saved but the live interval kept ticking → dialog appeared when the timer elapsed.

## Fix

- **Guard in `checkForUpdates()`**: automatic (non-interactive) checks now bail out early when `autoUpdate === false`. Manual menu checks (`interactive`) still always run. This defends every automatic caller regardless of scheduling.
- **Live teardown**: scheduling moved into `startUpdateChecks()` / `stopUpdateChecks()` helpers. The `save-check-for-updates` handler calls `startUpdateChecks()` so toggling takes effect immediately instead of only on next launch; timers are also torn down on `before-quit` (mirroring the allow-sleep watcher and MCP server).

## Testing

- `node --check` passes on both modified files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)